### PR TITLE
chore(gomod): downgraded golang with 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0]
+## [1.1.0] - 2024-2-13
 ### Added
 - added `BuilderOption` on `SetMap` on `InsertBuilder` and `UpdateBuilder` (#1)
 - added `WithAllow` BuilderOption (#2)


### PR DESCRIPTION
## Changes
- downgraded golang with v1.18 on go.mod