### PR TITLE
fix(sqlbuilder): sort columns in SetMap for PrepareStmt performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - added `BitBool` for mysql bit type (#11)
 - added `sharding` feature (#12)
-- added `On` on `DB` to enable AutoSharding feature(#13)
-- added `On` on `SQLBuilder` to enable AutoRotation feature(#13)
+- added `On` on `DB` to enable AutoSharding feature (#13)
+- added `On` on `SQLBuilder` to enable AutoRotation feature (#13)
 
 ### Fixed
-- fixed parameterized placeholder for postgresql(#12)
+- fixed parameterized placeholder for postgresql (#12)
+- sorted columns in `SetMap` for PrepareStmt performance (#14)
 
 ## [1.1.0] - 2024-02-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ func deleteAlbums(ids []int64) error {
 ```
 
 
-### Table Rotation
+## Table Rotation
 use `shardid.ID` to enable rotate feature for a table based on option (NoRotate/MonthlyRotate/WeeklyRotate/DailyRotate)
 
 ```
@@ -443,7 +443,7 @@ db.ExecBuilder(context.TODO(),b) //DELETE FROM `orders_20240220` WHERE order_id 
 see more [examples](sqlbuilder_test.go#L490)
 
 
-### Database Sharding
+## Database Sharding
 use `shardid.ID` to enable sharding feature for any sql
 ```
 gen := shardid.New(WithDatabase(10)) // 10 database instances
@@ -464,7 +464,7 @@ db.On(id). //automatically select database based on `id.DatabaseID`
 see more [examples](db_test.go#L49)
 
 
-## SQL Injection
+## Security: SQL Injection
 SQLE uses the database/sql‘s argument placeholders to build parameterized SQL statement, which will automatically escape arguments to avoid SQL injection. eg if postgresql is used in your app, please call [UsePostgres](use.go#L5) on SQLBuilder or change [DefaultSQLQuote](sqlbuilder.go?L16) and [DefaultSQLParameterize](sqlbuilder.go?L17) to update parameterization options.
 
 ```

--- a/sqlbuilder.go
+++ b/sqlbuilder.go
@@ -2,6 +2,7 @@ package sqle
 
 import (
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/yaitoo/sqle/shardid"
@@ -176,6 +177,40 @@ func (b *Builder) Delete(table string) *Builder {
 	b.SQL("DELETE FROM ").SQL(b.Quote).SQL(table).SQL(b.Quote)
 
 	return b
+}
+
+func (b *Builder) sortColumns(m map[string]any, opts ...BuilderOption) []string {
+
+	bo := &BuilderOptions{}
+	for _, opt := range opts {
+		opt(bo)
+	}
+
+	hasCustomizedColumns := len(bo.Columns) > 0
+
+	for n, v := range m {
+
+		name := n
+
+		if bo.ToName != nil {
+			name = bo.ToName(name)
+			if name != n {
+				m[name] = v
+			}
+
+		}
+
+		if !hasCustomizedColumns {
+			bo.Columns = append(bo.Columns, name)
+		}
+	}
+
+	if !hasCustomizedColumns {
+		sort.Strings(bo.Columns)
+	}
+
+	return bo.Columns
+
 }
 
 func (b *Builder) On(id shardid.ID) *Builder {

--- a/sqlbuilder_insert.go
+++ b/sqlbuilder_insert.go
@@ -61,22 +61,9 @@ func (ib *InsertBuilder) SetMap(m map[string]any, opts ...BuilderOption) *Insert
 		return ib
 	}
 
-	bo := &BuilderOptions{}
-	for _, opt := range opts {
-		opt(bo)
-	}
+	columns := ib.b.sortColumns(m, opts...)
 
-	for n, v := range m {
-		if bo.ToName != nil {
-			sn := bo.ToName(n)
-			if sn != n {
-				delete(m, n)
-				m[sn] = v
-			}
-		}
-	}
-
-	for _, n := range bo.Columns {
+	for _, n := range columns {
 		v, ok := m[n]
 		if ok {
 			ib.Set(n, v)

--- a/sqlbuilder_test.go
+++ b/sqlbuilder_test.go
@@ -528,6 +528,50 @@ func TestBuilder(t *testing.T) {
 
 			},
 		},
+		{
+			name: "build_with_map_should_be_sorted",
+			build: func() *Builder {
+				m := make(map[string]any)
+
+				m["user_id"] = "x1234"
+				m["id"] = 1
+
+				b := New().Insert("users").SetMap(m).End()
+
+				return b
+			},
+			assert: func(t *testing.T, b *Builder) {
+				s, vars, err := b.Build()
+				require.NoError(t, err)
+				require.Equal(t, "INSERT INTO `users` (`id`, `user_id`) VALUES (?, ?)", s)
+				require.Len(t, vars, 2)
+				require.Equal(t, 1, vars[0])
+				require.Equal(t, "x1234", vars[1])
+
+			},
+		},
+		{
+			name: "build_with_map_and_allow_should_not_be_sorted",
+			build: func() *Builder {
+				m := make(map[string]any)
+
+				m["user_id"] = "x1234"
+				m["id"] = 1
+
+				b := New().Insert("users").SetMap(m, WithAllow("user_id", "id")).End()
+
+				return b
+			},
+			assert: func(t *testing.T, b *Builder) {
+				s, vars, err := b.Build()
+				require.NoError(t, err)
+				require.Equal(t, "INSERT INTO `users` (`user_id`, `id`) VALUES (?, ?)", s)
+				require.Len(t, vars, 2)
+				require.Equal(t, "x1234", vars[0])
+				require.Equal(t, 1, vars[1])
+
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/sqlbuilder_update.go
+++ b/sqlbuilder_update.go
@@ -1,6 +1,8 @@
 package sqle
 
-import "reflect"
+import (
+	"reflect"
+)
 
 type UpdateBuilder struct {
 	*Builder
@@ -42,22 +44,9 @@ func (ub *UpdateBuilder) SetMap(m map[string]any, opts ...BuilderOption) *Update
 		return ub
 	}
 
-	bo := &BuilderOptions{}
-	for _, opt := range opts {
-		opt(bo)
-	}
+	columns := ub.sortColumns(m, opts...)
 
-	for n, v := range m {
-		if bo.ToName != nil {
-			sn := bo.ToName(n)
-			if sn != n {
-				delete(m, n)
-				m[sn] = v
-			}
-		}
-	}
-
-	for _, n := range bo.Columns {
+	for _, n := range columns {
 		v, ok := m[n]
 		if ok {
 			ub.Set(n, v)


### PR DESCRIPTION
## Fixes
- sort columns in `sqlbuilder.SetMap` to reduce PrepareStmt` for performance.