### PR TITLE
fix(sqlbuilder): input should always work even it is missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0]
+## [Unreleased]
+### Fixes
+- fixed missed input variable issue (#15)
+
+## [1.2.0] - 2024-02-36
 ### Added
 - added `BitBool` for mysql bit type (#11)
 - added `sharding` feature (#12)

--- a/sqlbuilder.go
+++ b/sqlbuilder.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	ErrInvalidInputVariable = errors.New("sqle: invalid input variable")
 	ErrInvalidParamVariable = errors.New("sqle: invalid param variable")
 )
 
@@ -100,10 +99,9 @@ func (b *Builder) Build() (string, []any, error) {
 		case InputToken:
 			n := t.String()
 			v, ok := b.inputs[n]
-			if !ok {
-				return "", nil, ErrInvalidInputVariable
+			if ok {
+				sb.WriteString(v)
 			}
-			sb.WriteString(v)
 
 		case ParamToken:
 			n := t.String()

--- a/sqlbuilder_test.go
+++ b/sqlbuilder_test.go
@@ -572,6 +572,28 @@ func TestBuilder(t *testing.T) {
 
 			},
 		},
+		{
+			name: "build_missed_input_should_work",
+			build: func() *Builder {
+				m := make(map[string]any)
+
+				m["user_id"] = "x1234"
+				m["id"] = 1
+
+				b := New().Insert("users<rotate>").SetMap(m, WithAllow("user_id", "id")).End()
+
+				return b
+			},
+			assert: func(t *testing.T, b *Builder) {
+				s, vars, err := b.Build()
+				require.NoError(t, err)
+				require.Equal(t, "INSERT INTO `users` (`user_id`, `id`) VALUES (?, ?)", s)
+				require.Len(t, vars, 2)
+				require.Equal(t, "x1234", vars[0])
+				require.Equal(t, 1, vars[1])
+
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Fixes
- input should always be replaced even it is missed.