### PR TITLE
fix(shardid): use string instead of int64 in id json Marshaler/Unmarshaler

### DIFF
--- a/shardid/id.go
+++ b/shardid/id.go
@@ -103,12 +103,12 @@ func (b *ID) Scan(src interface{}) error { // skipcq: GO-W1029
 }
 
 // MarshalJSON implements the json.Marshaler interface
-func (id ID) MarshalJSON() ([]byte, error) {
+func (id ID) MarshalJSON() ([]byte, error) { // skipcq: GO-W1029
 	return []byte(fmt.Sprintf(`"%d"`, id.Int64)), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface
-func (id *ID) UnmarshalJSON(data []byte) error {
+func (id *ID) UnmarshalJSON(data []byte) error { // skipcq: GO-W1029
 	s := string(data)
 
 	i, err := strconv.ParseInt(strings.Trim(s, "\""), 10, 64)

--- a/shardid/id.go
+++ b/shardid/id.go
@@ -2,8 +2,10 @@ package shardid
 
 import (
 	"database/sql/driver"
-	"encoding/json"
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -101,16 +103,19 @@ func (b *ID) Scan(src interface{}) error { // skipcq: GO-W1029
 }
 
 // MarshalJSON implements the json.Marshaler interface
-func (id ID) MarshalJSON() ([]byte, error) { // skipcq: GO-W1029
-	return json.Marshal(id.Int64)
+func (id ID) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%d"`, id.Int64)), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface
-func (id *ID) UnmarshalJSON(data []byte) error { // skipcq: GO-W1029
-	var value int64
-	if err := json.Unmarshal(data, &value); err != nil {
+func (id *ID) UnmarshalJSON(data []byte) error {
+	s := string(data)
+
+	i, err := strconv.ParseInt(strings.Trim(s, "\""), 10, 64)
+	if err != nil {
 		return err
 	}
-	*id = Parse(value)
+
+	*id = Parse(i)
 	return nil
 }

--- a/shardid/id_test.go
+++ b/shardid/id_test.go
@@ -132,7 +132,7 @@ func TestIDInSQL(t *testing.T) {
 func TestIdInJSON(t *testing.T) {
 
 	var v int64 = 89166347069554688
-	var s string = "89166347069554688"
+	var s = "89166347069554688"
 
 	bufStr, err := json.Marshal(s)
 	require.NoError(t, err)

--- a/shardid/id_test.go
+++ b/shardid/id_test.go
@@ -131,26 +131,28 @@ func TestIDInSQL(t *testing.T) {
 
 func TestIdInJSON(t *testing.T) {
 
-	now := time.Now()
-	id := Build(now.UnixMilli(), 1, 2, MonthlyRotate, 3)
+	var v int64 = 89166347069554688
+	var s string = "89166347069554688"
 
-	idInt64 := id.Int64
+	bufStr, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	id := Parse(v)
 
 	bufID, err := json.Marshal(id)
 	require.NoError(t, err)
 
-	bufIdInt64, err := json.Marshal(idInt64)
-	require.NoError(t, err)
-
-	require.Equal(t, bufIdInt64, bufID)
+	require.Equal(t, bufStr, bufID)
 
 	var jsID ID
-	err = json.Unmarshal(bufIdInt64, &jsID)
+	// Unmarshal id from string json bytes
+	err = json.Unmarshal(bufStr, &jsID)
 	require.NoError(t, err)
 	require.Equal(t, id, jsID)
 
-	var jsIdInt64 int64
-	err = json.Unmarshal(bufID, &jsIdInt64)
+	var jsString string
+	// Unmarshal string from ID json bytes
+	err = json.Unmarshal(bufID, &jsString)
 	require.NoError(t, err)
-	require.Equal(t, idInt64, jsIdInt64)
+	require.Equal(t, s, jsString)
 }


### PR DESCRIPTION
## Fixes
- fixed BigInt compatibility issue in browser javascript. 