### PR TITLE
fix(tx): added context in tx.QueryBuilder and tx.QueryRowBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.4.6] - 2014-04-21
+## [1.4.6] - 2014-04-23
 ### Changed
-- implements json.Marshaler and json.Unmarshaler on `ID` (#39)
+- implements json.Marshaler and json.Unmarshaler on `ID` (#41)
+- added `context` support in `tx.QueryRowBuilder` and `tx.QueryBuilder` (#42)
 
 ## [1.4.5] - 2014-04-20
-### Changed
-- used int64 instead of int in `Queryer.Count` (#37)
+### Fixes
+- fix(sqlbuilder): fixed WithWhere/WithOrderBy for empty builder (#39)
 - fixed timer performance issue (#38)
 - fixed StmtMaxIdleTime missing issue (#38)
+- used int64 instead of int in `Queryer.Count` (#37)
 
 ## [1.4.4] - 2014-04-19
 ### Added

--- a/tx.go
+++ b/tx.go
@@ -40,13 +40,13 @@ func (tx *Tx) Query(query string, args ...any) (*Rows, error) {
 	return tx.QueryContext(context.Background(), query, args...)
 }
 
-func (tx *Tx) QueryBuilder(b *Builder) (*Rows, error) {
+func (tx *Tx) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
 	query, args, err := b.Build()
 	if err != nil {
 		return nil, err
 	}
 
-	return tx.QueryContext(context.TODO(), query, args...)
+	return tx.QueryContext(ctx, query, args...)
 }
 
 func (tx *Tx) QueryContext(ctx context.Context, query string, args ...any) (*Rows, error) {
@@ -76,7 +76,7 @@ func (tx *Tx) QueryRow(query string, args ...any) *Row {
 	return tx.QueryRowContext(context.Background(), query, args...)
 }
 
-func (tx *Tx) QueryRowBuilder(b *Builder) *Row {
+func (tx *Tx) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
 	query, args, err := b.Build()
 	if err != nil {
 		return &Row{
@@ -84,7 +84,7 @@ func (tx *Tx) QueryRowBuilder(b *Builder) *Row {
 		}
 	}
 
-	return tx.QueryRowContext(context.TODO(), query, args...)
+	return tx.QueryRowContext(ctx, query, args...)
 }
 
 func (tx *Tx) QueryRowContext(ctx context.Context, query string, args ...any) *Row {

--- a/tx_test.go
+++ b/tx_test.go
@@ -61,7 +61,7 @@ func TestTx(t *testing.T) {
 				require.Equal(t, 3, users[2].ID)
 
 				users2 := make([]user, 0, 3)
-				rows, err = tx.Query("SELECT * FROM users WHERE id<4")
+				rows, err = tx.QueryBuilder(context.Background(), New("SELECT * FROM users WHERE id<{id}").Param("id", 4))
 				require.NoError(t, err)
 				err = rows.Bind(&users2)
 				require.NoError(t, err)
@@ -102,7 +102,7 @@ func TestTx(t *testing.T) {
 				require.Equal(t, "1zzzz", u.Salt)
 
 				var u2 user
-				row2 := tx.QueryRow("SELECT * FROM users WHERE id=?", 2)
+				row2 := tx.QueryRowBuilder(context.Background(), New("SELECT * FROM users WHERE id={id}").Param("id", 2))
 				err = row2.Bind(&u2)
 				require.NoError(t, err)
 


### PR DESCRIPTION
## Changes
- added `ctx context` in `tx.QueryBuilder` and `tx.QueryRowBuilder`