### PR TITLE
fix(rows): doesn't close rows on Scan

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           go-version: ^1.21
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54
+          version: v1.61
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.1] 
+## [1.5.2] - 2024-12-12
+- fix(rows): don't close rows in rows.Scan (#49)
+
+## [1.5.1] - 2024-06-12
 - !fix(orderby): use BuildOption instead of allowedColumns (#46)
 - feat(string): added nullable String/Null for sql/json (#47)
 

--- a/row.go
+++ b/row.go
@@ -77,13 +77,6 @@ func (r *Row) Bind(dest any) error {
 		return r.err
 	}
 
-	if !r.rows.Next() {
-		if err := r.rows.Err(); err != nil {
-			return err
-		}
-		return sql.ErrNoRows
-	}
-
 	v := reflect.ValueOf(dest)
 
 	if v.Kind() != reflect.Pointer {
@@ -95,6 +88,13 @@ func (r *Row) Bind(dest any) error {
 	}
 
 	var err error
+	if !r.rows.Next() {
+		err = r.rows.Err()
+		if err != nil {
+			return err
+		}
+		return sql.ErrNoRows
+	}
 
 	cols, err := getColumns(r.query, r.rows)
 	if err != nil {

--- a/row_test.go
+++ b/row_test.go
@@ -64,7 +64,7 @@ func (cb *customBinder) Bind(_ reflect.Value, columns []string) []any {
 	return values
 }
 
-func TestRowBind(t *testing.T) {
+func TestRow(t *testing.T) {
 
 	d, err := sql.Open("sqlite3", "file::memory:?cache=shared")
 	require.NoError(t, err)
@@ -91,6 +91,28 @@ func TestRowBind(t *testing.T) {
 		name string
 		run  func(t *testing.T)
 	}{
+		{
+			name: "close_should_always_work",
+			run: func(*testing.T) {
+
+				rows := &Row{}
+				rows.Close()
+			},
+		},
+		{
+			name: "bind_only_work_with_non_nil_pointer",
+			run: func(t *testing.T) {
+
+				rows := &Row{}
+				var dest int
+				err := rows.Bind(dest)
+				require.ErrorIs(t, err, ErrMustPointer)
+
+				var dest2 *int
+				err = rows.Bind(dest2)
+				require.ErrorIs(t, err, ErrMustNotNilPointer)
+			},
+		},
 		{
 			name: "full_columns_should_work",
 			run: func(t *testing.T) {

--- a/row_test.go
+++ b/row_test.go
@@ -94,22 +94,23 @@ func TestRow(t *testing.T) {
 		{
 			name: "close_should_always_work",
 			run: func(*testing.T) {
-
-				rows := &Row{}
-				rows.Close()
+				var row *Row
+				row.Close()
+				row = &Row{}
+				row.Close()
 			},
 		},
 		{
 			name: "bind_only_work_with_non_nil_pointer",
 			run: func(t *testing.T) {
 
-				rows := &Row{}
+				row := &Row{}
 				var dest int
-				err := rows.Bind(dest)
+				err := row.Bind(dest)
 				require.ErrorIs(t, err, ErrMustPointer)
 
 				var dest2 *int
-				err = rows.Bind(dest2)
+				err = row.Bind(dest2)
 				require.ErrorIs(t, err, ErrMustNotNilPointer)
 			},
 		},

--- a/rows.go
+++ b/rows.go
@@ -24,7 +24,6 @@ func (r *Rows) Close() error {
 }
 
 func (r *Rows) Scan(dest ...any) error {
-	defer r.Close()
 	return r.Rows.Scan(dest...)
 }
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -37,6 +37,40 @@ func TestRowsBind(t *testing.T) {
 		run  func(t *testing.T)
 	}{
 		{
+			name: "scan_on_rows_should_work",
+			run: func(t *testing.T) {
+				type user struct {
+					ID      int
+					Status  int
+					Email   string
+					Passwd  string
+					Salt    string
+					Created *time.Time
+				}
+				rows, err := db.Query("SELECT id,email FROM rows WHERE id<4")
+				require.NoError(t, err)
+
+				var id int
+				var email string
+
+				err = rows.Scan(&id, &email)
+				require.NoError(t, err)
+				require.Equal(t, 1, id)
+				require.Equal(t, "test1@mail.com", email)
+
+				err = rows.Scan(&id, &email)
+				require.NoError(t, err)
+				require.Equal(t, 2, id)
+				require.Equal(t, "test2@mail.com", email)
+
+				err = rows.Scan(&id, &email)
+				require.NoError(t, err)
+				require.Equal(t, 3, id)
+				require.Equal(t, "test3@mail.com", email)
+
+			},
+		},
+		{
 			name: "bind_slice_of_struct_should_work",
 			run: func(t *testing.T) {
 				type user struct {

--- a/rows_test.go
+++ b/rows_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRowsBind(t *testing.T) {
+func TestRows(t *testing.T) {
 
 	d, err := sql.Open("sqlite3", "file::memory:")
 	require.NoError(t, err)
@@ -36,6 +36,28 @@ func TestRowsBind(t *testing.T) {
 		name string
 		run  func(t *testing.T)
 	}{
+		{
+			name: "close_should_always_work",
+			run: func(t *testing.T) {
+
+				rows := &Rows{}
+				rows.Close()
+			},
+		},
+		{
+			name: "bind_only_work_with_non_nil_pointer",
+			run: func(t *testing.T) {
+
+				rows := &Rows{}
+				var dest int
+				err := rows.Bind(dest)
+				require.ErrorIs(t, err, ErrMustPointer)
+
+				var dest2 *int
+				err = rows.Bind(dest2)
+				require.ErrorIs(t, err, ErrMustNotNilPointer)
+			},
+		},
 		{
 			name: "scan_on_rows_should_work",
 			run: func(t *testing.T) {

--- a/rows_test.go
+++ b/rows_test.go
@@ -48,22 +48,21 @@ func TestRowsBind(t *testing.T) {
 				var id int
 				var email string
 
-				for rows.Next() {
-					err = rows.Scan(&id, &email)
-					require.NoError(t, err)
-					require.Equal(t, 1, id)
-					require.Equal(t, "test1@mail.com", email)
-
-					err = rows.Scan(&id, &email)
-					require.NoError(t, err)
-					require.Equal(t, 2, id)
-					require.Equal(t, "test2@mail.com", email)
-
-					err = rows.Scan(&id, &email)
-					require.NoError(t, err)
-					require.Equal(t, 3, id)
-					require.Equal(t, "test3@mail.com", email)
-				}
+				rows.Next()
+				err = rows.Scan(&id, &email)
+				require.NoError(t, err)
+				require.Equal(t, 1, id)
+				require.Equal(t, "test1@mail.com", email)
+				rows.Next()
+				err = rows.Scan(&id, &email)
+				require.NoError(t, err)
+				require.Equal(t, 2, id)
+				require.Equal(t, "test2@mail.com", email)
+				rows.Next()
+				err = rows.Scan(&id, &email)
+				require.NoError(t, err)
+				require.Equal(t, 3, id)
+				require.Equal(t, "test3@mail.com", email)
 			},
 		},
 		{

--- a/rows_test.go
+++ b/rows_test.go
@@ -38,7 +38,7 @@ func TestRows(t *testing.T) {
 	}{
 		{
 			name: "close_should_always_work",
-			run: func(t *testing.T) {
+			run: func(*testing.T) {
 
 				rows := &Rows{}
 				rows.Close()

--- a/rows_test.go
+++ b/rows_test.go
@@ -39,35 +39,31 @@ func TestRowsBind(t *testing.T) {
 		{
 			name: "scan_on_rows_should_work",
 			run: func(t *testing.T) {
-				type user struct {
-					ID      int
-					Status  int
-					Email   string
-					Passwd  string
-					Salt    string
-					Created *time.Time
-				}
+
 				rows, err := db.Query("SELECT id,email FROM rows WHERE id<4")
 				require.NoError(t, err)
+
+				defer rows.Close()
 
 				var id int
 				var email string
 
-				err = rows.Scan(&id, &email)
-				require.NoError(t, err)
-				require.Equal(t, 1, id)
-				require.Equal(t, "test1@mail.com", email)
+				for rows.Next() {
+					err = rows.Scan(&id, &email)
+					require.NoError(t, err)
+					require.Equal(t, 1, id)
+					require.Equal(t, "test1@mail.com", email)
 
-				err = rows.Scan(&id, &email)
-				require.NoError(t, err)
-				require.Equal(t, 2, id)
-				require.Equal(t, "test2@mail.com", email)
+					err = rows.Scan(&id, &email)
+					require.NoError(t, err)
+					require.Equal(t, 2, id)
+					require.Equal(t, "test2@mail.com", email)
 
-				err = rows.Scan(&id, &email)
-				require.NoError(t, err)
-				require.Equal(t, 3, id)
-				require.Equal(t, "test3@mail.com", email)
-
+					err = rows.Scan(&id, &email)
+					require.NoError(t, err)
+					require.Equal(t, 3, id)
+					require.Equal(t, "test3@mail.com", email)
+				}
 			},
 		},
 		{


### PR DESCRIPTION
# Fixes
- fixed #48 :  rows should not be closed in `Scan`, leave it to close by user.

## Summary by Sourcery

Fix the premature closing of rows in the Scan method and add a test to verify correct scanning behavior.

Bug Fixes:
- Fix the issue where rows were being closed prematurely in the Scan method, allowing users to manage the closing of rows themselves.

Tests:
- Add a test case to ensure that scanning on rows works correctly without closing them prematurely.