### PR TITLE
fix(migrate): improve migration status detection and prevent checksum conflicts

### DIFF
--- a/dtc_test.go
+++ b/dtc_test.go
@@ -33,19 +33,19 @@ func TestDTCWithDB(t *testing.T) {
 			setup: func() *DTC {
 				dtc := NewDTC(context.Background(), nil)
 
-				dtc.Prepare(db.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_1`(`id`,`email`) VALUES(?,?)", 1, "1@mail.com")
 
 					return err
 				}, nil)
 
-				dtc.Prepare(db.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_1`(`id`,`email`) VALUES(?,?)", 2, "2@mail.com")
 
 					return err
 				}, nil)
 
-				dtc.Prepare(db.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_1`(`id`,`email`) VALUES(?,?)", 3, "3@mail.com")
 
 					return err
@@ -72,19 +72,19 @@ func TestDTCWithDB(t *testing.T) {
 			name: "multiple_txs_rollback_should_work",
 			setup: func() *DTC {
 				dtc := NewDTC(context.Background(), nil)
-				dtc.Prepare(db.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_1`(`id`,`email`) VALUES(?,?)", 11, "1@mail.com")
 
 					return err
 				}, nil)
 
-				dtc.Prepare(db.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_1`(`id`,`email`) VALUES(?,?)", 12, "2@mail.com")
 
 					return err
 				}, nil)
 
-				dtc.Prepare(db.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_1`(`id`,`email`) VALUES(?,?)", 13)
 
 					return err
@@ -157,19 +157,19 @@ func TestDTCWithDBs(t *testing.T) {
 			setup: func() *DTC {
 				dtc := NewDTC(context.Background(), nil)
 
-				dtc.Prepare(db1.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db1.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_1` (`id`,`email`) VALUES(?,?)", 1, "1@mail.com")
 
 					return err
 				}, nil)
 
-				dtc.Prepare(db2.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db2.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_2` (`id`,`email`) VALUES(?,?)", 2, "2@mail.com")
 
 					return err
 				}, nil)
 
-				dtc.Prepare(db3.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db3.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_3` (`id`,`email`) VALUES(?,?)", 3, "3@mail.com")
 
 					return err
@@ -196,19 +196,19 @@ func TestDTCWithDBs(t *testing.T) {
 			name: "multiple_txs_rollback_should_work",
 			setup: func() *DTC {
 				dtc := NewDTC(context.Background(), nil)
-				dtc.Prepare(db1.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db1.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_1`(`id`,`email`) VALUES(?,?)", 11, "1@mail.com")
 
 					return err
 				}, nil)
 
-				dtc.Prepare(db2.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db2.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_2`(`id`,`email`) VALUES(?,?)", 12, "2@mail.com")
 
 					return err
 				}, nil)
 
-				dtc.Prepare(db3.dbs[0], func(ctx context.Context, conn Connector) error {
+				dtc.Prepare(db3.dbs[0], func(_ context.Context, conn Connector) error {
 					_, err := conn.Exec("INSERT INTO `dtc_3`(`id`,`email`) VALUES(?,?)", 13)
 
 					return err
@@ -273,28 +273,28 @@ func TestDTCRevert(t *testing.T) {
 
 	dtc := NewDTC(context.Background(), nil)
 
-	dtc.Prepare(db1.dbs[0], func(ctx context.Context, conn Connector) error {
+	dtc.Prepare(db1.dbs[0], func(_ context.Context, conn Connector) error {
 		_, err := conn.Exec("INSERT INTO `dtc_1` (`id`,`email`) VALUES(?,?)", 1, "1@mail.com")
 		return err
-	}, func(ctx context.Context, c Connector) error {
+	}, func(_ context.Context, c Connector) error {
 		_, err := c.Exec("DELETE FROM `dtc_1` WHERE id=?", 1)
 		return err
 	})
 
-	dtc.Prepare(db2.dbs[0], func(ctx context.Context, conn Connector) error {
+	dtc.Prepare(db2.dbs[0], func(_ context.Context, conn Connector) error {
 		_, err := conn.Exec("INSERT INTO `dtc_2` (`id`,`email`) VALUES(?,?)", 2, "2@mail.com")
 
 		return err
-	}, func(ctx context.Context, c Connector) error {
+	}, func(_ context.Context, c Connector) error {
 		_, err := c.Exec("DELETE FROM `dtc_2` WHERE id=?", 2)
 		return err
 	})
 
-	dtc.Prepare(db3.dbs[0], func(ctx context.Context, conn Connector) error {
+	dtc.Prepare(db3.dbs[0], func(_ context.Context, conn Connector) error {
 		_, err := conn.Exec("INSERT INTO `dtc_3` (`id`,`email`) VALUES(?,?)", 3, "3@mail.com")
 
 		return err
-	}, func(ctx context.Context, c Connector) error {
+	}, func(_ context.Context, c Connector) error {
 		_, err := c.Exec("DELETE FROM `dtc_3` WHERE id=?", 3)
 		return err
 	})

--- a/dtc_test.go
+++ b/dtc_test.go
@@ -10,9 +10,12 @@ import (
 )
 
 func TestDTCWithDB(t *testing.T) {
-	os.Remove("dtc_db.db")
+	os.Remove("dtc_1.db")
 
 	d, err := sql.Open("sqlite3", "file:dtc_1.db?cache=shared&mode=rwc")
+	require.NoError(t, err)
+
+	_, err = d.Exec("DROP TABLE IF EXISTS `dtc_1`")
 	require.NoError(t, err)
 
 	_, err = d.Exec("CREATE TABLE `dtc_1` (`id` int , `email` varchar(50),`created_at` DATETIME, PRIMARY KEY (`id`))")


### PR DESCRIPTION
## Summary by Sourcery

Improve migration status detection to distinguish between new, executed, and modified migrations and adjust migration execution accordingly.

Bug Fixes:
- Prevent re-execution of already run migrations when their checksum matches existing records.
- Avoid checksum conflicts by treating migrations with changed content but same identity as modified instead of new.

Enhancements:
- Introduce explicit migration status enum to clarify and centralize migration state handling.

Tests:
- Adjust DTC database test setup to clean up the specific database file and table before running.