### PR TITLE
feat: introduce Database interface for generic Open and extensible Client

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           go-version: ^1.21
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12
           only-new-issues: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v2.12
           only-new-issues: true
   unit-tests:
     name: Unit Tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+
+
 # Go workspace file
 go.work
 coverage.txt
+
+.serena/
+.cursor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,8 +373,8 @@ CREATE TABLE IF NOT EXISTS monthly_logs<rotate> (
 
 
 ## 3) Core types and flows
-- DB: sharding-aware wrapper over multiple Client instances; Open(*sql.DB...), Add, On(shardid.ID), NewDHT/GetDHT/OnDHT.
-- Client: wraps *sql.DB and caches prepared statements (Stmt). Provides Query/Exec and *Builder variants.
+- DB: sharding-aware wrapper over multiple Client instances; `Open[T Database](dbs ...T) *DB` (generic so `Open(dbs...)` works directly for `[]*sql.DB` or any custom Database slice), `Add(dbs ...Database)`, `On(shardid.ID)`, `NewDHT/GetDHT/OnDHT`.
+- Client: wraps a Database (anything that satisfies the Database interface; *sql.DB satisfies it by default) and caches prepared statements (Stmt). Provides Query/Exec and *Builder variants; Ping/PingContext/Close/Prepare/PrepareContext/Conn/Driver/Stats/SetMaxOpenConns/SetMaxIdleConns/SetConnMaxLifetime/SetConnMaxIdleTime forward to the wrapped Database so *DB keeps the same promoted API as before.
 - Tx: wraps *sql.Tx with local prepared statement cache.
 - Query[T]: high-level query facade over Queryer[T] (default MapR[T]). Supports First/Count/Query/QueryLimit and rotation window options.
 - Queryer[T]: interface to implement backends. Default MapR[T] fans out over dbs and rotated tables, merges and sorts.
@@ -491,7 +491,7 @@ Order/Where
 ## 16) File references (quick jump)
 - Builders: sqlbuilder.go, sqlbuilder_insert.go, sqlbuilder_update.go, sqlbuilder_where.go, sqlbuilder_orderby.go, sqlbuilder_option.go, use.go
 - Query: query.go, queryer.go, queryer_mapr.go, query_option.go
-- DB/Client/Tx: db.go, client.go, tx.go, client_stmt.go
+- DB/Client/Tx: database.go (Database interface), db.go, client.go, tx.go, client_stmt.go
 - Binding: binder.go, binder_struct.go, binder_map.go, scan.go, row.go, rows.go
 - Types: null.go, time.go, string.go, duration.go, bool.go
 - Sharding: shardid/*, db.go (On, DHT)

--- a/client.go
+++ b/client.go
@@ -3,13 +3,14 @@ package sqle
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"log"
 	"sync"
 	"time"
 )
 
 type Client struct {
-	*sql.DB
+	DB Database
 	sync.Mutex
 	_ noCopy
 
@@ -18,6 +19,67 @@ type Client struct {
 
 	stmtMaxIdleTime time.Duration
 	Index           int
+}
+
+// Ping forwards to the underlying Database. Kept so *DB keeps the
+// promoted method set that used to come from *sql.DB embedding.
+func (db *Client) Ping() error {
+	return db.DB.Ping()
+}
+
+// PingContext forwards to the underlying Database.
+func (db *Client) PingContext(ctx context.Context) error {
+	return db.DB.PingContext(ctx)
+}
+
+// Close forwards to the underlying Database.
+func (db *Client) Close() error {
+	return db.DB.Close()
+}
+
+// Conn forwards to the underlying Database.
+func (db *Client) Conn(ctx context.Context) (*sql.Conn, error) {
+	return db.DB.Conn(ctx)
+}
+
+// Driver forwards to the underlying Database.
+func (db *Client) Driver() driver.Driver {
+	return db.DB.Driver()
+}
+
+// Prepare forwards to the underlying Database, returning a raw *sql.Stmt.
+func (db *Client) Prepare(query string) (*sql.Stmt, error) {
+	return db.DB.Prepare(query)
+}
+
+// PrepareContext forwards to the underlying Database, returning a raw *sql.Stmt.
+func (db *Client) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return db.DB.PrepareContext(ctx, query)
+}
+
+// SetMaxOpenConns forwards to the underlying Database.
+func (db *Client) SetMaxOpenConns(n int) {
+	db.DB.SetMaxOpenConns(n)
+}
+
+// SetMaxIdleConns forwards to the underlying Database.
+func (db *Client) SetMaxIdleConns(n int) {
+	db.DB.SetMaxIdleConns(n)
+}
+
+// SetConnMaxLifetime forwards to the underlying Database.
+func (db *Client) SetConnMaxLifetime(d time.Duration) {
+	db.DB.SetConnMaxLifetime(d)
+}
+
+// SetConnMaxIdleTime forwards to the underlying Database.
+func (db *Client) SetConnMaxIdleTime(d time.Duration) {
+	db.DB.SetConnMaxIdleTime(d)
+}
+
+// Stats forwards to the underlying Database.
+func (db *Client) Stats() sql.DBStats {
+	return db.DB.Stats()
 }
 
 func (db *Client) Query(query string, args ...any) (*Rows, error) {

--- a/database.go
+++ b/database.go
@@ -1,0 +1,54 @@
+package sqle
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"time"
+)
+
+// Database abstracts the subset of *sql.DB used by sqle so that custom
+// wrappers (middleware, tracing, sharding proxies, mocks) can be plugged
+// in wherever sqle accepts a connection pool.
+//
+// *sql.DB satisfies this interface implicitly; callers using standard
+// library databases do not need to change anything. Begin/BeginTx continue
+// to return *sql.Tx because there is no Tx abstraction in sqle.
+type Database interface {
+	// Query
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+
+	// Exec
+	Exec(query string, args ...any) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+
+	// Prepare
+	Prepare(query string) (*sql.Stmt, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+
+	// Tx — sqle does not abstract Tx; callers receive the standard *sql.Tx.
+	Begin() (*sql.Tx, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+
+	// Conn / Driver
+	Conn(ctx context.Context) (*sql.Conn, error)
+	Driver() driver.Driver
+
+	// Lifecycle
+	Ping() error
+	PingContext(ctx context.Context) error
+	Close() error
+
+	// Pool
+	SetMaxOpenConns(n int)
+	SetMaxIdleConns(n int)
+	SetConnMaxLifetime(d time.Duration)
+	SetConnMaxIdleTime(d time.Duration)
+	Stats() sql.DBStats
+}
+
+// Compile-time assertion that *sql.DB satisfies Database.
+var _ Database = (*sql.DB)(nil)

--- a/database_test.go
+++ b/database_test.go
@@ -1,0 +1,64 @@
+package sqle
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/yaitoo/sqle/shardid"
+)
+
+// wrapperDB is a thin delegation wrapper around *sql.DB used to verify
+// that custom implementations of Database are accepted by Open.
+type wrapperDB struct {
+	*sql.DB
+}
+
+// TestOpenGenericSlice verifies that the generic Open signature accepts
+// a []*sql.DB slice directly (no manual conversion needed) thanks to
+// the type parameter constrained by Database.
+func TestOpenGenericSlice(t *testing.T) {
+	dbs := []*sql.DB{createSQLite3(), createSQLite3()}
+
+	db := Open(dbs...)
+	require.NotNil(t, db)
+	require.Equal(t, 0, db.On(shardid.ID{DatabaseID: 0}).Index)
+}
+
+// TestDatabaseWrapper proves that a custom type satisfying Database
+// (here a thin *sql.DB wrapper) plugs into Open without changes.
+func TestDatabaseWrapper(t *testing.T) {
+	raw := createSQLite3()
+	raw.Exec("CREATE TABLE `t` (`v` int)") //nolint: errcheck
+
+	wrapped := &wrapperDB{DB: raw}
+
+	db := Open(wrapped)
+
+	ctx := context.Background()
+
+	// Exec via wrapper
+	res, err := db.ExecContext(ctx, "INSERT INTO `t` (`v`) VALUES (?)", 42)
+	require.NoError(t, err)
+	affected, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+
+	// Query via wrapper
+	var v int
+	row := db.QueryRowContext(ctx, "SELECT `v` FROM `t` WHERE `v` = ?", 42)
+	require.NoError(t, row.Scan(&v))
+	require.Equal(t, 42, v)
+
+	// Forwarded methods still work
+	require.NotNil(t, db.Stats())
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+	db.SetConnMaxIdleTime(0)
+
+	require.NoError(t, db.PingContext(ctx))
+	require.NoError(t, db.Ping())
+}

--- a/db.go
+++ b/db.go
@@ -1,7 +1,6 @@
 package sqle
 
 import (
-	"database/sql"
 	"errors"
 	"sync"
 	"time"
@@ -25,7 +24,11 @@ type DB struct {
 }
 
 // Open creates a new DB instance with the provided database connections.
-func Open(dbs ...*sql.DB) *DB {
+// Any value satisfying the Database interface is accepted; *sql.DB
+// satisfies it out of the box. The type parameter lets callers pass
+// a `[]*sql.DB` (or any other Database-conforming type) slice directly
+// via `Open(dbs...)`.
+func Open[T Database](dbs ...T) *DB {
 	d := &DB{
 		dhts: make(map[string]*shardid.DHT),
 	}
@@ -46,8 +49,13 @@ func Open(dbs ...*sql.DB) *DB {
 	return d
 }
 
-// Add dynamically scales out the DB with new databases.
-func (db *DB) Add(dbs ...*sql.DB) {
+// Add dynamically scales out the DB with new databases. Go does not
+// allow type parameters on methods of non-generic types, so callers
+// passing a []*sql.DB slice must convert it via a small helper (or use
+// individual arguments). For typical scale-out patterns this is not a
+// friction point; the primary entry point that benefits from generic
+// variadic is Open.
+func (db *DB) Add(dbs ...Database) {
 	db.Lock()
 	defer db.Unlock()
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a provider-agnostic Database abstraction and make the sharded DB/client layer work with it while preserving the existing *sql.DB-style API.

Enhancements:
- Refactor Client to wrap a generic Database implementation instead of embedding *sql.DB, while forwarding core connection and configuration methods to maintain compatibility with existing callers.
- Generalize DB.Open to accept any type implementing the Database interface via a generic entry point, and update DB.Add to scale out with arbitrary Database implementations.
- Update AGENTS.md to document the new Database interface, the generic Open signature, and the Client’s forwarded methods and file layout.