### PR TITLE
fix(migrate): strip SQL comments before splitting statements on semicolons

### DIFF
--- a/migrate/comment.go
+++ b/migrate/comment.go
@@ -1,0 +1,121 @@
+package migrate
+
+import "strings"
+
+// stripSQLComments removes SQL single-line (`-- …`) and multi-line
+// (`/* … */`) comments from a script so the caller can safely split
+// it on `;` without treating a semicolon inside a comment as a
+// statement terminator.
+//
+// String literals are recognised so that `--` or `/*` inside a
+// literal is left alone:
+//   - '…' single-quoted strings, with the standard '' escape
+//   - "…" double-quoted strings (e.g. MySQL with ANSI_QUOTES off)
+//   - `…` backtick-quoted strings (MySQL identifiers), with \ escapes
+//
+// `--` is only treated as the start of a comment when it appears at a
+// real token boundary — the start of the script, after whitespace,
+// or after a delimiter such as `; ( ) , ' " \`` — so that constructs
+// like `5--3` are not silently mutated. `/*` has no such ambiguity
+// in SQL and is always treated as the start of a block comment.
+func stripSQLComments(scripts string) string {
+	var b strings.Builder
+	b.Grow(len(scripts))
+
+	n := len(scripts)
+
+	inLine := false    // inside a -- ... \n comment
+	inBlock := false   // inside a /* ... */ comment
+	inString := false  // inside a '...' string literal
+	inQString := false // inside a "..." or `...` quoted identifier/string
+
+	for i := 0; i < n; i++ {
+		c := scripts[i]
+
+		if inLine {
+			if c == '\n' {
+				inLine = false
+				b.WriteByte(c)
+			}
+			continue
+		}
+
+		if inBlock {
+			if c == '*' && i+1 < n && scripts[i+1] == '/' {
+				inBlock = false
+				i++ // skip the closing '/'
+			}
+			continue
+		}
+
+		if inString {
+			b.WriteByte(c)
+			if c == '\'' {
+				if i+1 < n && scripts[i+1] == '\'' {
+					// SQL '' escape: keep both quotes inside the string.
+					b.WriteByte(scripts[i+1])
+					i++
+				} else {
+					inString = false
+				}
+			}
+			continue
+		}
+
+		if inQString {
+			b.WriteByte(c)
+			if c == '\\' && i+1 < n {
+				// Backslash escape for " or ` (MySQL).
+				b.WriteByte(scripts[i+1])
+				i++
+				continue
+			}
+			if c == '"' || c == '`' {
+				inQString = false
+			}
+			continue
+		}
+
+		if c == '\'' {
+			inString = true
+			b.WriteByte(c)
+			continue
+		}
+
+		if c == '"' || c == '`' {
+			inQString = true
+			b.WriteByte(c)
+			continue
+		}
+
+		if c == '-' && i+1 < n && scripts[i+1] == '-' && isLineCommentStart(scripts, i) {
+			inLine = true
+			i++ // skip the second '-'
+			continue
+		}
+
+		if c == '/' && i+1 < n && scripts[i+1] == '*' {
+			inBlock = true
+			i++ // skip the '*'
+			continue
+		}
+
+		b.WriteByte(c)
+	}
+
+	return b.String()
+}
+
+// isLineCommentStart reports whether the '-' at position i in scripts
+// is at a real token boundary and therefore starts an SQL line
+// comment.
+func isLineCommentStart(scripts string, i int) bool {
+	if i == 0 {
+		return true
+	}
+	switch scripts[i-1] {
+	case ' ', '\t', '\n', '\r', ';', '(', ',', ')', '\'', '"', '`':
+		return true
+	}
+	return false
+}

--- a/migrate/comment.go
+++ b/migrate/comment.go
@@ -10,11 +10,16 @@ import "strings"
 // String literals are recognised so that `--` or `/*` inside a
 // literal is left alone:
 //   - '…' single-quoted strings, with the standard '' escape
-//   - "…" double-quoted strings (e.g. MySQL with ANSI_QUOTES off)
-//   - `…` backtick-quoted strings (MySQL identifiers), with \ escapes
+//   - "…" double-quoted strings, with "" and \" escapes
+//   - `…` backtick-quoted strings, with `` and \ escapes
 //
-// `--` is only treated as the start of a comment when it appears at a
-// real token boundary — the start of the script, after whitespace,
+// For double-quoted and backtick-quoted literals we remember which
+// delimiter opened the literal and only close it on the same
+// character, so a backtick inside a double-quoted string (or vice
+// versa) is not mistaken for the closing delimiter.
+//
+// `--` is only treated as the start of a comment when it appears at
+// a real token boundary — the start of the script, after whitespace,
 // or after a delimiter such as `; ( ) , ' " \`` — so that constructs
 // like `5--3` are not silently mutated. `/*` has no such ambiguity
 // in SQL and is always treated as the start of a block comment.
@@ -24,10 +29,11 @@ func stripSQLComments(scripts string) string {
 
 	n := len(scripts)
 
-	inLine := false    // inside a -- ... \n comment
-	inBlock := false   // inside a /* ... */ comment
-	inString := false  // inside a '...' string literal
-	inQString := false // inside a "..." or `...` quoted identifier/string
+	inLine := false   // inside a -- ... \n comment
+	inBlock := false  // inside a /* ... */ comment
+	inString := false // inside a '...' string literal
+	qDelim := byte(0) // 0 when not inside a "..." or `...` literal;
+	// otherwise the opening quote ('"' or '`')
 
 	for i := 0; i < n; i++ {
 		c := scripts[i]
@@ -62,16 +68,24 @@ func stripSQLComments(scripts string) string {
 			continue
 		}
 
-		if inQString {
+		if qDelim != 0 {
 			b.WriteByte(c)
 			if c == '\\' && i+1 < n {
-				// Backslash escape for " or ` (MySQL).
+				// Backslash escape (MySQL).
 				b.WriteByte(scripts[i+1])
 				i++
 				continue
 			}
-			if c == '"' || c == '`' {
-				inQString = false
+			// Doubled-delimiter escape (SQL standard): "" inside "",
+			// `` inside ``. This is the only way to embed the same
+			// delimiter inside a quoted literal without using \.
+			if c == qDelim && i+1 < n && scripts[i+1] == qDelim {
+				b.WriteByte(scripts[i+1])
+				i++
+				continue
+			}
+			if c == qDelim {
+				qDelim = 0
 			}
 			continue
 		}
@@ -83,7 +97,7 @@ func stripSQLComments(scripts string) string {
 		}
 
 		if c == '"' || c == '`' {
-			inQString = true
+			qDelim = c
 			b.WriteByte(c)
 			continue
 		}

--- a/migrate/comment_test.go
+++ b/migrate/comment_test.go
@@ -240,6 +240,30 @@ func TestStripSQLComments(t *testing.T) {
 			want: `SELECT "a\"b" FROM t;`,
 		},
 		{
+			name: "double_quoted_string_with_doubled_quote_escape",
+			in:   `SELECT "a""b" FROM t;`,
+			want: `SELECT "a""b" FROM t;`,
+		},
+		{
+			name: "double_quoted_string_with_only_doubled_quote",
+			in:   `SELECT "" FROM t;`,
+			want: `SELECT "" FROM t;`,
+		},
+		{
+			name: "backtick_inside_double_quoted_preserved",
+			// backtick inside a "..." literal must not close the
+			// double-quoted string.
+			in:   "SELECT \"a`b\" FROM t;",
+			want: "SELECT \"a`b\" FROM t;",
+		},
+		{
+			name: "double_quoted_containing_backtick_and_semicolon",
+			// a backtick and a semicolon inside "..." must not end
+			// the string nor be misread as a statement separator.
+			in:   "SELECT \"a`; SELECT 2\" FROM t;",
+			want: "SELECT \"a`; SELECT 2\" FROM t;",
+		},
+		{
 			name: "unterminated_double_quoted_string",
 			in:   `SELECT "never closes`,
 			want: `SELECT "never closes`,
@@ -267,9 +291,38 @@ func TestStripSQLComments(t *testing.T) {
 			want: "SELECT `a\\`b` FROM t;",
 		},
 		{
+			name: "backtick_string_with_doubled_backtick_escape",
+			// MySQL lets you escape a backtick inside a backtick
+			// identifier by doubling it.
+			in:   "SELECT `a``b` FROM t;",
+			want: "SELECT `a``b` FROM t;",
+		},
+		{
 			name: "unterminated_backtick_string",
 			in:   "SELECT `never closes",
 			want: "SELECT `never closes",
+		},
+		{
+			name: "double_quote_inside_backtick_preserved",
+			// a " inside a `...` literal must not close the
+			// backtick string, and any subsequent text must remain
+			// inside the literal.
+			in:   "SELECT `a\"b` FROM t;",
+			want: "SELECT `a\"b` FROM t;",
+		},
+		{
+			name: "backtick_string_containing_double_quote_and_semicolon",
+			in:   "SELECT `a\"; SELECT 2` FROM t;",
+			want: "SELECT `a\"; SELECT 2` FROM t;",
+		},
+		{
+			name: "real_comment_after_backtick_with_double_quote_inside",
+			// a real `--` comment after a backtick string that
+			// itself contains a `"` must be stripped. The previous
+			// (buggy) implementation left it untouched because it
+			// thought the `"` inside the literal had closed it.
+			in:   "SELECT `a\"b` -- real comment\nFROM t;",
+			want: "SELECT `a\"b` \nFROM t;",
 		},
 
 		// --- combined end-to-end scripts ---

--- a/migrate/comment_test.go
+++ b/migrate/comment_test.go
@@ -1,0 +1,354 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripSQLComments(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// --- baseline ---
+		{
+			name: "no_comments",
+			in:   "CREATE TABLE foo (id INT);",
+			want: "CREATE TABLE foo (id INT);",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "only_whitespace",
+			in:   "  \n\t",
+			want: "  \n\t",
+		},
+
+		// --- `--` line comment at token boundaries (must be stripped) ---
+		{
+			name: "line_comment_at_start_of_file",
+			in:   "-- drop foo; keep bar;\nCREATE TABLE foo (id INT);",
+			want: "\nCREATE TABLE foo (id INT);",
+		},
+		{
+			name: "line_comment_after_newline",
+			in:   "SELECT 5;\n-- a note;\nSELECT 6;",
+			want: "SELECT 5;\n\nSELECT 6;",
+		},
+		{
+			name: "line_comment_after_space",
+			in:   "SELECT 5 -- a note;\n; SELECT 6;",
+			want: "SELECT 5 \n; SELECT 6;",
+		},
+		{
+			name: "line_comment_after_tab",
+			in:   "SELECT 5\t-- a note\n;",
+			want: "SELECT 5\t\n;",
+		},
+		{
+			name: "line_comment_after_carriage_return",
+			in:   "SELECT 5\r-- a note\n;",
+			want: "SELECT 5\r\n;",
+		},
+		{
+			name: "line_comment_after_semicolon",
+			in:   "SELECT 5;-- a note",
+			want: "SELECT 5;",
+		},
+		{
+			name: "line_comment_after_open_paren",
+			in:   "VALUES (-- a note\n1)",
+			want: "VALUES (\n1)",
+		},
+		{
+			name: "line_comment_after_comma",
+			in:   "VALUES (1, -- a note\n2)",
+			want: "VALUES (1, \n2)",
+		},
+		{
+			name: "line_comment_after_close_paren",
+			in:   "(1) -- a note",
+			want: "(1) ",
+		},
+		{
+			name: "line_comment_after_single_quote",
+			in:   "SELECT 'a'-- a note\nFROM t;",
+			want: "SELECT 'a'\nFROM t;",
+		},
+		{
+			name: "line_comment_after_double_quote",
+			in:   `SELECT "a"-- a note` + "\nFROM t;",
+			want: `SELECT "a"` + "\nFROM t;",
+		},
+		{
+			name: "line_comment_after_backtick",
+			in:   "SELECT `a`-- a note\nFROM t;",
+			want: "SELECT `a`\nFROM t;",
+		},
+		{
+			name: "line_comment_at_eof_no_newline",
+			in:   "SELECT 5;-- trailing",
+			want: "SELECT 5;",
+		},
+
+		// --- `--` at non-boundary positions (must NOT be stripped) ---
+		{
+			name: "dash_dash_after_digit_preserved",
+			in:   "5--3",
+			want: "5--3",
+		},
+		{
+			name: "dash_dash_after_letter_preserved",
+			in:   "a--b",
+			want: "a--b",
+		},
+		{
+			name: "dash_dash_after_keyword_preserved",
+			in:   "SELECT--comment\nFROM t;",
+			want: "SELECT--comment\nFROM t;",
+		},
+		{
+			name: "dash_dash_after_dot_preserved",
+			in:   "1.5--3",
+			want: "1.5--3",
+		},
+		{
+			name: "dash_dash_after_plus_preserved",
+			in:   "5+-3",
+			want: "5+-3",
+		},
+		{
+			name: "dash_dash_after_equals_preserved",
+			in:   "a=--b",
+			want: "a=--b",
+		},
+		{
+			name: "dash_dash_after_another_dash_preserved",
+			in:   "5---3",
+			want: "5---3",
+		},
+
+		// --- `/* … */` block comment (always a comment, no boundary check) ---
+		{
+			name: "block_comment_at_start_of_file",
+			in:   "/* drop foo; keep bar; */\nCREATE TABLE foo (id INT);",
+			want: "\nCREATE TABLE foo (id INT);",
+		},
+		{
+			name: "block_comment_after_digit",
+			in:   "5/*3*/x",
+			want: "5x",
+		},
+		{
+			name: "block_comment_after_letter",
+			in:   "a/*b*/x",
+			want: "ax",
+		},
+		{
+			name: "block_comment_spans_lines",
+			in:   "/* line one;\n   line two;\n*/\nCREATE TABLE foo (id INT);",
+			want: "\nCREATE TABLE foo (id INT);",
+		},
+		{
+			name: "empty_block_comment",
+			in:   "SELECT 1 /**/ ;",
+			want: "SELECT 1  ;",
+		},
+		{
+			name: "block_comment_with_star_inside",
+			in:   "/* a * b */ x",
+			want: " x",
+		},
+		{
+			name: "line_comment_inside_block_comment",
+			in:   "/* outer -- with semicolon; still inside */ CREATE TABLE foo (id INT);",
+			want: " CREATE TABLE foo (id INT);",
+		},
+		{
+			name: "nested_lookalike_block_inside_block",
+			in:   "/* outer /* inner */ still inside */ x",
+			want: " still inside */ x",
+		},
+		{
+			name: "unterminated_block_comment",
+			in:   "/* still inside; never closes\nCREATE TABLE foo (id INT);",
+			want: "",
+		},
+
+		// --- single-quoted strings ---
+		{
+			name: "single_quoted_string_with_dash_dash",
+			in:   "SELECT 'a--b' FROM t;",
+			want: "SELECT 'a--b' FROM t;",
+		},
+		{
+			name: "single_quoted_string_with_block_comment",
+			in:   "SELECT 'a/*b' FROM t;",
+			want: "SELECT 'a/*b' FROM t;",
+		},
+		{
+			name: "single_quoted_string_with_semicolon",
+			in:   "SELECT 'a;b' FROM t;",
+			want: "SELECT 'a;b' FROM t;",
+		},
+		{
+			name: "single_quoted_string_with_escaped_quote",
+			in:   "SELECT 'it''s; ok' FROM t;",
+			want: "SELECT 'it''s; ok' FROM t;",
+		},
+		{
+			name: "single_quoted_string_with_newline",
+			in:   "SELECT 'a\nb' FROM t;",
+			want: "SELECT 'a\nb' FROM t;",
+		},
+		{
+			name: "dash_dash_inside_then_line_comment_outside",
+			in:   "SELECT 'a--b' -- real comment\nFROM t;",
+			want: "SELECT 'a--b' \nFROM t;",
+		},
+		{
+			name: "unterminated_single_quoted_string",
+			in:   "SELECT 'never closes",
+			want: "SELECT 'never closes",
+		},
+
+		// --- double-quoted strings (MySQL with ANSI_QUOTES off, or ANSI SQL) ---
+		{
+			name: "double_quoted_string_with_dash_dash",
+			in:   `SELECT "a--b" FROM t;`,
+			want: `SELECT "a--b" FROM t;`,
+		},
+		{
+			name: "double_quoted_string_with_block_comment",
+			in:   `SELECT "a/*b" FROM t;`,
+			want: `SELECT "a/*b" FROM t;`,
+		},
+		{
+			name: "double_quoted_string_with_semicolon",
+			in:   `SELECT "a;b" FROM t;`,
+			want: `SELECT "a;b" FROM t;`,
+		},
+		{
+			name: "double_quoted_string_with_backslash_escape",
+			in:   `SELECT "a\"b" FROM t;`,
+			want: `SELECT "a\"b" FROM t;`,
+		},
+		{
+			name: "unterminated_double_quoted_string",
+			in:   `SELECT "never closes`,
+			want: `SELECT "never closes`,
+		},
+
+		// --- backtick strings (MySQL identifiers) ---
+		{
+			name: "backtick_string_with_dash_dash",
+			in:   "SELECT `a--b` FROM t;",
+			want: "SELECT `a--b` FROM t;",
+		},
+		{
+			name: "backtick_string_with_block_comment",
+			in:   "SELECT `a/*b` FROM t;",
+			want: "SELECT `a/*b` FROM t;",
+		},
+		{
+			name: "backtick_string_with_semicolon",
+			in:   "SELECT `a;b` FROM t;",
+			want: "SELECT `a;b` FROM t;",
+		},
+		{
+			name: "backtick_string_with_backslash_escape",
+			in:   "SELECT `a\\`b` FROM t;",
+			want: "SELECT `a\\`b` FROM t;",
+		},
+		{
+			name: "unterminated_backtick_string",
+			in:   "SELECT `never closes",
+			want: "SELECT `never closes",
+		},
+
+		// --- combined end-to-end scripts ---
+		{
+			name: "multiple_statements_with_mixed_comments",
+			in: "CREATE TABLE a (id INT); -- done with a;\n" +
+				"CREATE TABLE b (id INT); /* done with b; */\n" +
+				"CREATE TABLE c (id INT);",
+			want: "CREATE TABLE a (id INT); \n" +
+				"CREATE TABLE b (id INT); \n" +
+				"CREATE TABLE c (id INT);",
+		},
+		{
+			name: "semicolon_in_string_then_real_semicolon",
+			in:   "INSERT INTO foo VALUES ('a;b'); INSERT INTO bar VALUES (1);",
+			want: "INSERT INTO foo VALUES ('a;b'); INSERT INTO bar VALUES (1);",
+		},
+		{
+			name: "comment_with_quote_inside_does_not_open_string",
+			in:   "SELECT 1; -- it's a comment\nSELECT 2;",
+			want: "SELECT 1; \nSELECT 2;",
+		},
+		{
+			name: "block_comment_with_single_quote_inside",
+			in:   "/* it's a comment; with 'quote' */ SELECT 1;",
+			want: " SELECT 1;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, stripSQLComments(tt.in))
+		})
+	}
+}
+
+// TestStripSQLCommentsSemicolonSplit documents the bug we are fixing:
+// before stripSQLComments was added, splitting a script on ';' would
+// treat ';' inside a comment as a statement terminator and the
+// non-SQL fragment from the comment would then be executed.
+func TestStripSQLCommentsSemicolonSplit(t *testing.T) {
+	script := "-- TODO: drop foo; keep bar;\nCREATE TABLE foo (id INT);"
+
+	naive := strings.Split(script, ";")
+	// Naive split yields a comment-only fragment as a "statement".
+	require.Contains(t, naive[0], "-- TODO: drop foo")
+
+	clean := strings.Split(stripSQLComments(script), ";")
+	// After stripping, the only non-empty statement is the CREATE TABLE.
+	var nonEmpty []string
+	for _, s := range clean {
+		if strings.TrimSpace(s) != "" {
+			nonEmpty = append(nonEmpty, s)
+		}
+	}
+	require.Len(t, nonEmpty, 1)
+	require.Contains(t, nonEmpty[0], "CREATE TABLE foo")
+}
+
+// TestStripSQLCommentsLegitimateContentPreserved asserts that the
+// helper does not silently delete content that is not a comment:
+// numbers, identifiers, dotted decimals, and string contents must
+// round-trip unchanged.
+func TestStripSQLCommentsLegitimateContentPreserved(t *testing.T) {
+	inputs := []string{
+		"SELECT 5--3",                    // -- after digit, not a comment
+		"SELECT a--b",                    // -- after letter, not a comment
+		"SELECT 1.5--3",                  // -- after digit in decimal
+		"SELECT 5+-3",                    // -- after operator
+		"SELECT 5---3",                   // -- after another dash
+		"SELECT `a--b` FROM t",           // -- inside backtick
+		`SELECT "a--b" FROM t`,           // -- inside double-quoted
+		"SELECT 'a--b' FROM t",           // -- inside single-quoted
+		"SELECT 'a/*b' FROM t",           // /* inside single-quoted
+		"INSERT INTO foo VALUES ('a;b')", // ; inside single-quoted
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			require.Equal(t, in, stripSQLComments(in))
+		})
+	}
+}

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -264,7 +264,7 @@ func (m *Migrator) startMigrate(ctx context.Context, db *sqle.DB) error {
 				rotations := m.buildRotations(s.Rotate, s.RotateBegin, s.RotateEnd)
 
 				now := time.Now()
-				for _, it := range strings.Split(s.Scripts, ";") {
+				for _, it := range strings.Split(stripSQLComments(s.Scripts), ";") {
 					it := strings.TrimSpace(it)
 					if it != "" {
 						for _, rt := range rotations {

--- a/migrate/migrator_test.go
+++ b/migrate/migrator_test.go
@@ -514,6 +514,46 @@ func TestMigrate(t *testing.T) {
 			},
 		},
 		{
+			name: "semicolons_in_comments_should_not_split_statements",
+			setup: func(db *sql.DB) (*Migrator, error) {
+
+				m := New(sqle.Open(db))
+
+				err := m.Discover(fstest.MapFS{
+					"0.1.0/1_create_with_comments.sql": &fstest.MapFile{
+						Data: []byte(`-- TODO: drop foo; keep bar;
+CREATE TABLE IF NOT EXISTS foo (
+	id int NOT NULL,
+	PRIMARY KEY (id)
+);
+/* a block comment; with a semicolon */
+CREATE TABLE IF NOT EXISTS bar (
+	id int NOT NULL,
+	PRIMARY KEY (id)
+);`),
+					},
+				})
+
+				if err != nil {
+					return nil, err
+				}
+
+				return m, nil
+
+			},
+			assert: func(t *testing.T, m *Migrator) {
+				err := m.dbs[0].QueryRow("SELECT id FROM foo WHERE id=?", 0).Bind(&struct {
+					ID int
+				}{})
+				require.ErrorIs(t, err, sql.ErrNoRows)
+
+				err = m.dbs[0].QueryRow("SELECT id FROM bar WHERE id=?", 0).Bind(&struct {
+					ID int
+				}{})
+				require.ErrorIs(t, err, sql.ErrNoRows)
+			},
+		},
+		{
 			name: "with_invalid_rotate_should_be_skipped",
 			setup: func(db *sql.DB) (*Migrator, error) {
 


### PR DESCRIPTION

## Summary by Sourcery

Strip SQL comments from migration scripts before splitting on semicolons to prevent executing comment fragments as statements.

Bug Fixes:
- Ensure semicolons inside SQL line and block comments do not cause scripts to be split into invalid statements during migration.

Tests:
- Add comprehensive unit tests for SQL comment stripping, including edge cases with strings and unterminated comments, and integrate this helper into migration tests verifying tables are created correctly.