### PR TITLE
feat(tx): introduce Tx interface for generic Open and extensible Client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ _ = db.QueryBuilder(ctx, sqle.New().Select("users")).Bind(&items)
 
 - Transactions
 ```
-_ = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.RawTx) error {
+_ = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.Transaction) error {
     if _, err := tx.Exec("UPDATE accounts SET balance=balance-? WHERE id=?", amt, from); err != nil { return err }
     if _, err := tx.Exec("UPDATE accounts SET balance=balance+? WHERE id=?", amt, to); err != nil { return err }
     // Read within tx
@@ -376,7 +376,7 @@ CREATE TABLE IF NOT EXISTS monthly_logs<rotate> (
 - DB: sharding-aware wrapper over multiple Client instances; `Open(dbArgs ...any) *DB` (accepts *sql.DB and any Database-conforming type at runtime; sqlDBWrapper adapts *sql.DB internally), `OpenDB(dbs ...*sql.DB) *DB` (type-safe convenience), `Add(dbs ...Database)`, `On(shardid.ID)`, `NewDHT/GetDHT/OnDHT`.
 - Client: wraps a Database (anything that satisfies the Database interface; *sql.DB is wrapped via sqlDBWrapper so it conforms) and caches prepared statements (Stmt). Provides Query/Exec and *Builder variants; Ping/PingContext/Close/Prepare/PrepareContext/Conn/Driver/Stats/SetMaxOpenConns/SetMaxIdleConns/SetConnMaxLifetime/SetConnMaxIdleTime forward to the wrapped Database so *DB keeps the same promoted API as before.
 - Tx interface: abstracts the subset of *sql.Tx used by sqle (Query/QueryContext/QueryRow/QueryRowContext/Exec/ExecContext/Prepare/PrepareContext/Commit/Rollback). *sql.Tx satisfies it implicitly; custom Database implementations can return custom transaction types.
-- RawTx: wraps a Tx interface with a per-transaction prepared statement cache. Returned by Client.BeginTx/Transaction so callers can use the cached prepared statements (Query/Exec/ExecBuilder/QueryBuilder return sqle's *Rows/*Row).
+- Transaction: wraps a Tx interface with a per-transaction prepared statement cache. Returned by Client.BeginTx/Transaction so callers can use the cached prepared statements (Query/Exec/ExecBuilder/QueryBuilder return sqle's *Rows/*Row).
 - Query[T]: high-level query facade over Queryer[T] (default MapR[T]). Supports First/Count/Query/QueryLimit and rotation window options.
 - Queryer[T]: interface to implement backends. Default MapR[T] fans out over dbs and rotated tables, merges and sorts.
 - Builder: SQL string builder with inputs (raw) and params (bound). Sub-builders: InsertBuilder, UpdateBuilder, WhereBuilder, OrderByBuilder.
@@ -439,8 +439,8 @@ Order/Where
 
 
 ## 9) Transactions
-- db.Transaction(ctx, opts, func(ctx, tx *RawTx) error { ... }) with auto commit/rollback.
-- RawTx wraps the Tx interface and supports Query/Exec and *Builder variants; local prepare cache used when args present.
+- db.Transaction(ctx, opts, func(ctx, tx *Transaction) error { ... }) with auto commit/rollback.
+- Transaction wraps the Tx interface and supports Query/Exec and *Builder variants; local prepare cache used when args present.
 - Tx interface is the abstraction over *sql.Tx; it lets custom Database implementations provide their own transaction types (e.g., tracing wrappers, custom driver implementations, mocks).
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ _ = db.QueryBuilder(ctx, sqle.New().Select("users")).Bind(&items)
 
 - Transactions
 ```
-_ = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.TxContext) error {
+_ = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.RawTx) error {
     if _, err := tx.Exec("UPDATE accounts SET balance=balance-? WHERE id=?", amt, from); err != nil { return err }
     if _, err := tx.Exec("UPDATE accounts SET balance=balance+? WHERE id=?", amt, to); err != nil { return err }
     // Read within tx
@@ -376,7 +376,7 @@ CREATE TABLE IF NOT EXISTS monthly_logs<rotate> (
 - DB: sharding-aware wrapper over multiple Client instances; `Open(dbArgs ...any) *DB` (accepts *sql.DB and any Database-conforming type at runtime; sqlDBWrapper adapts *sql.DB internally), `OpenDB(dbs ...*sql.DB) *DB` (type-safe convenience), `Add(dbs ...Database)`, `On(shardid.ID)`, `NewDHT/GetDHT/OnDHT`.
 - Client: wraps a Database (anything that satisfies the Database interface; *sql.DB is wrapped via sqlDBWrapper so it conforms) and caches prepared statements (Stmt). Provides Query/Exec and *Builder variants; Ping/PingContext/Close/Prepare/PrepareContext/Conn/Driver/Stats/SetMaxOpenConns/SetMaxIdleConns/SetConnMaxLifetime/SetConnMaxIdleTime forward to the wrapped Database so *DB keeps the same promoted API as before.
 - Tx interface: abstracts the subset of *sql.Tx used by sqle (Query/QueryContext/QueryRow/QueryRowContext/Exec/ExecContext/Prepare/PrepareContext/Commit/Rollback). *sql.Tx satisfies it implicitly; custom Database implementations can return custom transaction types.
-- TxContext: wraps a Tx interface with a per-transaction prepared statement cache. Returned by Client.BeginTx/Transaction so callers can use the cached prepared statements (Query/Exec/ExecBuilder/QueryBuilder return sqle's *Rows/*Row).
+- RawTx: wraps a Tx interface with a per-transaction prepared statement cache. Returned by Client.BeginTx/Transaction so callers can use the cached prepared statements (Query/Exec/ExecBuilder/QueryBuilder return sqle's *Rows/*Row).
 - Query[T]: high-level query facade over Queryer[T] (default MapR[T]). Supports First/Count/Query/QueryLimit and rotation window options.
 - Queryer[T]: interface to implement backends. Default MapR[T] fans out over dbs and rotated tables, merges and sorts.
 - Builder: SQL string builder with inputs (raw) and params (bound). Sub-builders: InsertBuilder, UpdateBuilder, WhereBuilder, OrderByBuilder.
@@ -439,8 +439,8 @@ Order/Where
 
 
 ## 9) Transactions
-- db.Transaction(ctx, opts, func(ctx, tx *TxContext) error { ... }) with auto commit/rollback.
-- TxContext wraps the Tx interface and supports Query/Exec and *Builder variants; local prepare cache used when args present.
+- db.Transaction(ctx, opts, func(ctx, tx *RawTx) error { ... }) with auto commit/rollback.
+- RawTx wraps the Tx interface and supports Query/Exec and *Builder variants; local prepare cache used when args present.
 - Tx interface is the abstraction over *sql.Tx; it lets custom Database implementations provide their own transaction types (e.g., tracing wrappers, custom driver implementations, mocks).
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ _ = db.QueryBuilder(ctx, sqle.New().Select("users")).Bind(&items)
 
 - Transactions
 ```
-_ = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.Tx) error {
+_ = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.TxContext) error {
     if _, err := tx.Exec("UPDATE accounts SET balance=balance-? WHERE id=?", amt, from); err != nil { return err }
     if _, err := tx.Exec("UPDATE accounts SET balance=balance+? WHERE id=?", amt, to); err != nil { return err }
     // Read within tx
@@ -373,9 +373,10 @@ CREATE TABLE IF NOT EXISTS monthly_logs<rotate> (
 
 
 ## 3) Core types and flows
-- DB: sharding-aware wrapper over multiple Client instances; `Open[T Database](dbs ...T) *DB` (generic so `Open(dbs...)` works directly for `[]*sql.DB` or any custom Database slice), `Add(dbs ...Database)`, `On(shardid.ID)`, `NewDHT/GetDHT/OnDHT`.
-- Client: wraps a Database (anything that satisfies the Database interface; *sql.DB satisfies it by default) and caches prepared statements (Stmt). Provides Query/Exec and *Builder variants; Ping/PingContext/Close/Prepare/PrepareContext/Conn/Driver/Stats/SetMaxOpenConns/SetMaxIdleConns/SetConnMaxLifetime/SetConnMaxIdleTime forward to the wrapped Database so *DB keeps the same promoted API as before.
-- Tx: wraps *sql.Tx with local prepared statement cache.
+- DB: sharding-aware wrapper over multiple Client instances; `Open(dbArgs ...any) *DB` (accepts *sql.DB and any Database-conforming type at runtime; sqlDBWrapper adapts *sql.DB internally), `OpenDB(dbs ...*sql.DB) *DB` (type-safe convenience), `Add(dbs ...Database)`, `On(shardid.ID)`, `NewDHT/GetDHT/OnDHT`.
+- Client: wraps a Database (anything that satisfies the Database interface; *sql.DB is wrapped via sqlDBWrapper so it conforms) and caches prepared statements (Stmt). Provides Query/Exec and *Builder variants; Ping/PingContext/Close/Prepare/PrepareContext/Conn/Driver/Stats/SetMaxOpenConns/SetMaxIdleConns/SetConnMaxLifetime/SetConnMaxIdleTime forward to the wrapped Database so *DB keeps the same promoted API as before.
+- Tx interface: abstracts the subset of *sql.Tx used by sqle (Query/QueryContext/QueryRow/QueryRowContext/Exec/ExecContext/Prepare/PrepareContext/Commit/Rollback). *sql.Tx satisfies it implicitly; custom Database implementations can return custom transaction types.
+- TxContext: wraps a Tx interface with a per-transaction prepared statement cache. Returned by Client.BeginTx/Transaction so callers can use the cached prepared statements (Query/Exec/ExecBuilder/QueryBuilder return sqle's *Rows/*Row).
 - Query[T]: high-level query facade over Queryer[T] (default MapR[T]). Supports First/Count/Query/QueryLimit and rotation window options.
 - Queryer[T]: interface to implement backends. Default MapR[T] fans out over dbs and rotated tables, merges and sorts.
 - Builder: SQL string builder with inputs (raw) and params (bound). Sub-builders: InsertBuilder, UpdateBuilder, WhereBuilder, OrderByBuilder.
@@ -438,8 +439,9 @@ Order/Where
 
 
 ## 9) Transactions
-- db.Transaction(ctx, opts, func(ctx, tx) error { ... }) with auto commit/rollback.
-- Tx supports Query/Exec and *Builder variants; local prepare cache used when args present.
+- db.Transaction(ctx, opts, func(ctx, tx *TxContext) error { ... }) with auto commit/rollback.
+- TxContext wraps the Tx interface and supports Query/Exec and *Builder variants; local prepare cache used when args present.
+- Tx interface is the abstraction over *sql.Tx; it lets custom Database implementations provide their own transaction types (e.g., tracing wrappers, custom driver implementations, mocks).
 
 
 ## 10) Distributed transactions (DTC)
@@ -491,7 +493,7 @@ Order/Where
 ## 16) File references (quick jump)
 - Builders: sqlbuilder.go, sqlbuilder_insert.go, sqlbuilder_update.go, sqlbuilder_where.go, sqlbuilder_orderby.go, sqlbuilder_option.go, use.go
 - Query: query.go, queryer.go, queryer_mapr.go, query_option.go
-- DB/Client/Tx: database.go (Database interface), db.go, client.go, tx.go, client_stmt.go
+- DB/Client/Tx: database.go (Database & Tx interfaces), db.go, client.go, tx.go, client_stmt.go
 - Binding: binder.go, binder_struct.go, binder_map.go, scan.go, row.go, rows.go
 - Types: null.go, time.go, string.go, duration.go, bool.go
 - Sharding: shardid/*, db.go (On, DHT)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - !feat(tx): introduce `Tx` interface mirroring the `Database` interface for custom transaction implementations
-- !refactor: rename `Tx` struct to `TxContext` so the `Tx` interface can coexist; `*sql.Tx` is wrapped via `sqlDBWrapper`/`OpenDB` for backward compatibility
+- !refactor: rename `Tx` struct to `RawTx` so the `Tx` interface can coexist; `*sql.Tx` is wrapped via `sqlDBWrapper`/`OpenDB` for backward compatibility
 - !refactor: change `Open` to accept `...any` (runtime-adapts `*sql.DB` and `Database`); add `OpenDB(...*sql.DB)` as a type-safe convenience
 
 ## [1.5.2] - 2024-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- !feat(tx): introduce `Tx` interface mirroring the `Database` interface for custom transaction implementations
+- !refactor: rename `Tx` struct to `TxContext` so the `Tx` interface can coexist; `*sql.Tx` is wrapped via `sqlDBWrapper`/`OpenDB` for backward compatibility
+- !refactor: change `Open` to accept `...any` (runtime-adapts `*sql.DB` and `Database`); add `OpenDB(...*sql.DB)` as a type-safe convenience
+
 ## [1.5.2] - 2024-12-12
 - fix(rows): don't close rows in rows.Scan (#49)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - !feat(tx): introduce `Tx` interface mirroring the `Database` interface for custom transaction implementations
-- !refactor: rename `Tx` struct to `RawTx` so the `Tx` interface can coexist; `*sql.Tx` is wrapped via `sqlDBWrapper`/`OpenDB` for backward compatibility
+- !refactor: rename `Tx` struct to `Transaction` so the `Tx` interface can coexist; `*sql.Tx` is wrapped via `sqlDBWrapper`/`OpenDB` for backward compatibility
 - !refactor: change `Open` to accept `...any` (runtime-adapts `*sql.DB` and `Database`); add `OpenDB(...*sql.DB)` as a type-safe convenience
 
 ## [1.5.2] - 2024-12-12

--- a/client.go
+++ b/client.go
@@ -197,21 +197,21 @@ func (db *Client) ExecContext(ctx context.Context, query string, args ...any) (s
 	return db.DB.ExecContext(context.Background(), query, args...)
 }
 
-func (db *Client) Begin(opts *sql.TxOptions) (*RawTx, error) {
+func (db *Client) Begin(opts *sql.TxOptions) (*Transaction, error) {
 	return db.BeginTx(context.TODO(), opts)
 
 }
 
-func (db *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*RawTx, error) {
+func (db *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Transaction, error) {
 	tx, err := db.DB.BeginTx(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return &RawTx{Tx: tx, stmts: make(map[string]*sql.Stmt)}, nil
+	return &Transaction{Tx: tx, stmts: make(map[string]*sql.Stmt)}, nil
 }
 
-func (db *Client) Transaction(ctx context.Context, opts *sql.TxOptions, fn func(ctx context.Context, tx *RawTx) error) error {
+func (db *Client) Transaction(ctx context.Context, opts *sql.TxOptions, fn func(ctx context.Context, tx *Transaction) error) error {
 	tx, err := db.BeginTx(ctx, opts)
 	if err != nil {
 		return err

--- a/client.go
+++ b/client.go
@@ -197,21 +197,21 @@ func (db *Client) ExecContext(ctx context.Context, query string, args ...any) (s
 	return db.DB.ExecContext(context.Background(), query, args...)
 }
 
-func (db *Client) Begin(opts *sql.TxOptions) (*Tx, error) {
+func (db *Client) Begin(opts *sql.TxOptions) (*TxContext, error) {
 	return db.BeginTx(context.TODO(), opts)
 
 }
 
-func (db *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
+func (db *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxContext, error) {
 	tx, err := db.DB.BeginTx(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Tx{Tx: tx, stmts: make(map[string]*sql.Stmt)}, nil
+	return &TxContext{Tx: tx, stmts: make(map[string]*sql.Stmt)}, nil
 }
 
-func (db *Client) Transaction(ctx context.Context, opts *sql.TxOptions, fn func(ctx context.Context, tx *Tx) error) error {
+func (db *Client) Transaction(ctx context.Context, opts *sql.TxOptions, fn func(ctx context.Context, tx *TxContext) error) error {
 	tx, err := db.BeginTx(ctx, opts)
 	if err != nil {
 		return err

--- a/client.go
+++ b/client.go
@@ -197,21 +197,21 @@ func (db *Client) ExecContext(ctx context.Context, query string, args ...any) (s
 	return db.DB.ExecContext(context.Background(), query, args...)
 }
 
-func (db *Client) Begin(opts *sql.TxOptions) (*TxContext, error) {
+func (db *Client) Begin(opts *sql.TxOptions) (*RawTx, error) {
 	return db.BeginTx(context.TODO(), opts)
 
 }
 
-func (db *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxContext, error) {
+func (db *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*RawTx, error) {
 	tx, err := db.DB.BeginTx(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return &TxContext{Tx: tx, stmts: make(map[string]*sql.Stmt)}, nil
+	return &RawTx{Tx: tx, stmts: make(map[string]*sql.Stmt)}, nil
 }
 
-func (db *Client) Transaction(ctx context.Context, opts *sql.TxOptions, fn func(ctx context.Context, tx *TxContext) error) error {
+func (db *Client) Transaction(ctx context.Context, opts *sql.TxOptions, fn func(ctx context.Context, tx *RawTx) error) error {
 	tx, err := db.BeginTx(ctx, opts)
 	if err != nil {
 		return err

--- a/database.go
+++ b/database.go
@@ -11,9 +11,10 @@ import (
 // wrappers (middleware, tracing, sharding proxies, mocks) can be plugged
 // in wherever sqle accepts a connection pool.
 //
-// *sql.DB satisfies this interface implicitly; callers using standard
-// library databases do not need to change anything. Begin/BeginTx continue
-// to return *sql.Tx because there is no Tx abstraction in sqle.
+// *sql.DB does NOT satisfy Database directly because Begin/BeginTx
+// return *sql.Tx rather than the Tx interface. The internal sqlDBWrapper
+// adapts *sql.DB; Open applies it automatically when an *sql.DB is
+// passed.
 type Database interface {
 	// Query
 	Query(query string, args ...any) (*sql.Rows, error)
@@ -29,9 +30,9 @@ type Database interface {
 	Prepare(query string) (*sql.Stmt, error)
 	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
 
-	// Tx — sqle does not abstract Tx; callers receive the standard *sql.Tx.
-	Begin() (*sql.Tx, error)
-	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+	// Tx — returned values satisfy the Tx interface; *sql.Tx satisfies it by default.
+	Begin() (Tx, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error)
 
 	// Conn / Driver
 	Conn(ctx context.Context) (*sql.Conn, error)
@@ -50,5 +51,49 @@ type Database interface {
 	Stats() sql.DBStats
 }
 
-// Compile-time assertion that *sql.DB satisfies Database.
-var _ Database = (*sql.DB)(nil)
+// Tx abstracts the subset of *sql.Tx used by sqle so that custom
+// transaction implementations (middleware, tracing, sharding proxies,
+// mocks) can be plugged in alongside a Database.
+//
+// *sql.Tx satisfies this interface implicitly; callers using the
+// standard library do not need to change anything.
+type Tx interface {
+	// Query
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+
+	// Exec
+	Exec(query string, args ...any) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+
+	// Prepare
+	Prepare(query string) (*sql.Stmt, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+
+	// Lifecycle
+	Commit() error
+	Rollback() error
+}
+
+// sqlDBWrapper adapts *sql.DB to the Database interface by routing
+// Begin/BeginTx results through the Tx interface.
+type sqlDBWrapper struct {
+	*sql.DB
+}
+
+// Begin wraps *sql.DB.Begin so the returned *sql.Tx is exposed as the
+// Tx interface.
+func (db *sqlDBWrapper) Begin() (Tx, error) {
+	return db.DB.Begin()
+}
+
+// BeginTx wraps *sql.DB.BeginTx so the returned *sql.Tx is exposed as
+// the Tx interface.
+func (db *sqlDBWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error) {
+	return db.DB.BeginTx(ctx, opts)
+}
+
+// Compile-time assertion that *sql.Tx satisfies Tx.
+var _ Tx = (*sql.Tx)(nil)

--- a/database.go
+++ b/database.go
@@ -95,5 +95,12 @@ func (db *sqlDBWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, e
 	return db.DB.BeginTx(ctx, opts)
 }
 
-// Compile-time assertion that *sql.Tx satisfies Tx.
-var _ Tx = (*sql.Tx)(nil)
+// Compile-time assertions:
+//   - *sql.Tx must continue to satisfy Tx so Open/Add/OpenDB paths
+//     keep working without a wrapper for transactions.
+//   - *sqlDBWrapper must satisfy Database so the auto-wrap used by
+//     Open/OpenDB/AddDB/WrapSQLDB keeps type-checking.
+var (
+	_ Tx       = (*sql.Tx)(nil)
+	_ Database = (*sqlDBWrapper)(nil)
+)

--- a/database_test.go
+++ b/database_test.go
@@ -16,13 +16,23 @@ type wrapperDB struct {
 	*sql.DB
 }
 
+// Begin satisfies Database by adapting *sql.DB.Begin to the Tx interface.
+func (db *wrapperDB) Begin() (Tx, error) {
+	return db.DB.Begin()
+}
+
+// BeginTx satisfies Database by adapting *sql.DB.BeginTx to the Tx interface.
+func (db *wrapperDB) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error) {
+	return db.DB.BeginTx(ctx, opts)
+}
+
 // TestOpenGenericSlice verifies that the generic Open signature accepts
 // a []*sql.DB slice directly (no manual conversion needed) thanks to
 // the type parameter constrained by Database.
 func TestOpenGenericSlice(t *testing.T) {
 	dbs := []*sql.DB{createSQLite3(), createSQLite3()}
 
-	db := Open(dbs...)
+	db := OpenDB(dbs...)
 	require.NotNil(t, db)
 	require.Equal(t, 0, db.On(shardid.ID{DatabaseID: 0}).Index)
 }

--- a/db.go
+++ b/db.go
@@ -1,7 +1,9 @@
 package sqle
 
 import (
+	"database/sql"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -24,11 +26,30 @@ type DB struct {
 }
 
 // Open creates a new DB instance with the provided database connections.
-// Any value satisfying the Database interface is accepted; *sql.DB
-// satisfies it out of the box. The type parameter lets callers pass
-// a `[]*sql.DB` (or any other Database-conforming type) slice directly
-// via `Open(dbs...)`.
-func Open[T Database](dbs ...T) *DB {
+// Each argument must be either a Database implementation (custom
+// middleware, tracing, mocks, etc.) or a *sql.DB (which is wrapped
+// internally via sqlDBWrapper so it satisfies the Database interface).
+//
+// *sql.DB values are detected at runtime and wrapped automatically —
+// callers using the standard library do not need to wrap them manually.
+func Open(dbArgs ...any) *DB {
+	dbs := make([]Database, len(dbArgs))
+	for i, arg := range dbArgs {
+		switch v := arg.(type) {
+		case Database:
+			dbs[i] = v
+		case *sql.DB:
+			dbs[i] = &sqlDBWrapper{DB: v}
+		default:
+			panic(fmt.Sprintf("sqle: Open argument %d has unsupported type %T", i, arg))
+		}
+	}
+
+	return openDatabases(dbs...)
+}
+
+// openDatabases is the internal constructor used by Open and OpenDB.
+func openDatabases(dbs ...Database) *DB {
 	d := &DB{
 		dhts: make(map[string]*shardid.DHT),
 	}
@@ -49,12 +70,20 @@ func Open[T Database](dbs ...T) *DB {
 	return d
 }
 
-// Add dynamically scales out the DB with new databases. Go does not
-// allow type parameters on methods of non-generic types, so callers
-// passing a []*sql.DB slice must convert it via a small helper (or use
-// individual arguments). For typical scale-out patterns this is not a
-// friction point; the primary entry point that benefits from generic
-// variadic is Open.
+// OpenDB is the type-safe convenience for callers using *sql.DB
+// directly. It applies sqlDBWrapper to each *sql.DB so they satisfy
+// the Database interface, then delegates to openDatabases.
+func OpenDB(dbs ...*sql.DB) *DB {
+	wrapped := make([]Database, len(dbs))
+	for i, db := range dbs {
+		wrapped[i] = &sqlDBWrapper{DB: db}
+	}
+	return openDatabases(wrapped...)
+}
+
+// Add dynamically scales out the DB with new databases. Each value
+// must satisfy the Database interface; callers passing *sql.DB should
+// wrap each one with sqlDBWrapper (or define a custom Database type).
 func (db *DB) Add(dbs ...Database) {
 	db.Lock()
 	defer db.Unlock()

--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenDB(dbs ...*sql.DB) *DB {
 
 // Add dynamically scales out the DB with new databases. Each value
 // must satisfy the Database interface; callers passing *sql.DB should
-// wrap each one with sqlDBWrapper (or define a custom Database type).
+// wrap each one with sqlDBWrapper (or use AddDB as a convenience).
 func (db *DB) Add(dbs ...Database) {
 	db.Lock()
 	defer db.Unlock()
@@ -100,6 +100,25 @@ func (db *DB) Add(dbs ...Database) {
 		db.dbs = append(db.dbs, ctx)
 		go ctx.checkIdleStmt()
 	}
+}
+
+// AddDB is the type-safe convenience for callers using *sql.DB slices
+// with Add. It applies sqlDBWrapper to each *sql.DB so they satisfy
+// the Database interface, then delegates to Add.
+func (db *DB) AddDB(dbs ...*sql.DB) {
+	wrapped := make([]Database, len(dbs))
+	for i, d := range dbs {
+		wrapped[i] = &sqlDBWrapper{DB: d}
+	}
+	db.Add(wrapped...)
+}
+
+// WrapSQLDB adapts an *sql.DB to the Database interface, applying the
+// same internal sqlDBWrapper used by Open/AddDB/OpenDB. It is exported
+// for callers that need to convert individual *sql.DB values (e.g. for
+// mixed Database slices) without going through the variadic helpers.
+func WrapSQLDB(db *sql.DB) Database {
+	return &sqlDBWrapper{DB: db}
 }
 
 // On selects the database context based on the shardid ID.

--- a/db_test.go
+++ b/db_test.go
@@ -99,7 +99,7 @@ func TestDHT(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, ctx.Index)
 
-	db.Add(&sqlDBWrapper{DB: createSQLite3()})
+	db.AddDB(createSQLite3())
 	db.GetDHT("").Add(1)
 	db.GetDHT("").Done()
 

--- a/db_test.go
+++ b/db_test.go
@@ -45,7 +45,7 @@ func TestOn(t *testing.T) {
 		dbs = append(dbs, db3)
 	}
 
-	db := Open(dbs...)
+	db := OpenDB(dbs...)
 	gen := shardid.New(shardid.WithDatabase(10))
 
 	ids := make([]shardid.ID, 10)
@@ -99,7 +99,7 @@ func TestDHT(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, ctx.Index)
 
-	db.Add(createSQLite3())
+	db.Add(&sqlDBWrapper{DB: createSQLite3()})
 	db.GetDHT("").Add(1)
 	db.GetDHT("").Done()
 
@@ -124,7 +124,7 @@ func TestOnDHT(t *testing.T) {
 		dbs = append(dbs, db3)
 	}
 
-	db := Open(dbs...)
+	db := OpenDB(dbs...)
 
 	//	2 dbs   ->   3 dbs  -> data
 	//  -> 2439456            1149
@@ -210,7 +210,7 @@ func TestDHTScaling(t *testing.T) {
 		dbs = append(dbs, db3)
 	}
 
-	db := Open(dbs...)
+	db := OpenDB(dbs...)
 
 	//	2 dbs   ->   3 dbs  -> data
 	//  -> 2439456            1149

--- a/dtc.go
+++ b/dtc.go
@@ -17,7 +17,7 @@ type DTC struct {
 type session struct {
 	committed bool
 	client    *Client
-	tx        *RawTx
+	tx        *Transaction
 	exec      []func(context.Context, Connector) error
 	revert    []func(context.Context, Connector) error
 }

--- a/dtc.go
+++ b/dtc.go
@@ -17,7 +17,7 @@ type DTC struct {
 type session struct {
 	committed bool
 	client    *Client
-	tx        *Tx
+	tx        *TxContext
 	exec      []func(context.Context, Connector) error
 	revert    []func(context.Context, Connector) error
 }

--- a/dtc.go
+++ b/dtc.go
@@ -17,7 +17,7 @@ type DTC struct {
 type session struct {
 	committed bool
 	client    *Client
-	tx        *TxContext
+	tx        *RawTx
 	exec      []func(context.Context, Connector) error
 	revert    []func(context.Context, Connector) error
 }

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -243,7 +243,7 @@ func (m *Migrator) startMigrate(ctx context.Context, db *sqle.DB) error {
 		n := len(v.Migrations)
 		w := len(strconv.Itoa(n))
 		log.Printf("┌─[ v%s ]\n", v.Name)
-		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.TxContext) error {
+		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.RawTx) error {
 
 			for i, s := range v.Migrations {
 				status, err := m.getMigrationStatus(tx, v.Name, s)
@@ -322,7 +322,7 @@ func (m *Migrator) startMigrate(ctx context.Context, db *sqle.DB) error {
 	return nil
 }
 
-func (m *Migrator) getMigrationStatus(tx *sqle.TxContext, version string, s Migration) (MigrationStatus, error) {
+func (m *Migrator) getMigrationStatus(tx *sqle.RawTx, version string, s Migration) (MigrationStatus, error) {
 	// First check if checksum already exists (most common case: script already executed)
 	var checksum string
 	err := tx.QueryRow("SELECT checksum FROM sqle_migrations WHERE checksum = ?",
@@ -428,7 +428,7 @@ func startRotate(ctx context.Context, db *sqle.DB, rotatedNames []string, rotati
 	var w int
 	var checksum string
 	for _, r := range rotations {
-		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.TxContext) error {
+		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.RawTx) error {
 			n = len(rotatedNames)
 			w = len(strconv.Itoa(n))
 			log.Printf("┌─[ %s ]\n", r.Name)

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -243,7 +243,7 @@ func (m *Migrator) startMigrate(ctx context.Context, db *sqle.DB) error {
 		n := len(v.Migrations)
 		w := len(strconv.Itoa(n))
 		log.Printf("┌─[ v%s ]\n", v.Name)
-		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.Tx) error {
+		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.TxContext) error {
 
 			for i, s := range v.Migrations {
 				status, err := m.getMigrationStatus(tx, v.Name, s)
@@ -322,7 +322,7 @@ func (m *Migrator) startMigrate(ctx context.Context, db *sqle.DB) error {
 	return nil
 }
 
-func (m *Migrator) getMigrationStatus(tx *sqle.Tx, version string, s Migration) (MigrationStatus, error) {
+func (m *Migrator) getMigrationStatus(tx *sqle.TxContext, version string, s Migration) (MigrationStatus, error) {
 	// First check if checksum already exists (most common case: script already executed)
 	var checksum string
 	err := tx.QueryRow("SELECT checksum FROM sqle_migrations WHERE checksum = ?",
@@ -428,7 +428,7 @@ func startRotate(ctx context.Context, db *sqle.DB, rotatedNames []string, rotati
 	var w int
 	var checksum string
 	for _, r := range rotations {
-		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.Tx) error {
+		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.TxContext) error {
 			n = len(rotatedNames)
 			w = len(strconv.Itoa(n))
 			log.Printf("┌─[ %s ]\n", r.Name)

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -243,7 +243,7 @@ func (m *Migrator) startMigrate(ctx context.Context, db *sqle.DB) error {
 		n := len(v.Migrations)
 		w := len(strconv.Itoa(n))
 		log.Printf("┌─[ v%s ]\n", v.Name)
-		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.RawTx) error {
+		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.Transaction) error {
 
 			for i, s := range v.Migrations {
 				status, err := m.getMigrationStatus(tx, v.Name, s)
@@ -322,7 +322,7 @@ func (m *Migrator) startMigrate(ctx context.Context, db *sqle.DB) error {
 	return nil
 }
 
-func (m *Migrator) getMigrationStatus(tx *sqle.RawTx, version string, s Migration) (MigrationStatus, error) {
+func (m *Migrator) getMigrationStatus(tx *sqle.Transaction, version string, s Migration) (MigrationStatus, error) {
 	// First check if checksum already exists (most common case: script already executed)
 	var checksum string
 	err := tx.QueryRow("SELECT checksum FROM sqle_migrations WHERE checksum = ?",
@@ -428,7 +428,7 @@ func startRotate(ctx context.Context, db *sqle.DB, rotatedNames []string, rotati
 	var w int
 	var checksum string
 	for _, r := range rotations {
-		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.RawTx) error {
+		err = db.Transaction(ctx, nil, func(ctx context.Context, tx *sqle.Transaction) error {
 			n = len(rotatedNames)
 			w = len(strconv.Itoa(n))
 			log.Printf("┌─[ %s ]\n", r.Name)

--- a/queryer_mapr_test.go
+++ b/queryer_mapr_test.go
@@ -114,7 +114,7 @@ func TestFirst(t *testing.T) {
 	dbs, clean := createSQLites()
 	defer clean()
 
-	db := Open(dbs...)
+	db := OpenDB(dbs...)
 
 	tests := []struct {
 		name    string
@@ -299,7 +299,7 @@ func TestCount(t *testing.T) {
 	dbs, clean := createSQLites()
 	defer clean()
 
-	db := Open(dbs...)
+	db := OpenDB(dbs...)
 
 	tests := []struct {
 		name    string
@@ -471,7 +471,7 @@ func TestQuery(t *testing.T) {
 	dbs, clean := createSQLites()
 	defer clean()
 
-	db := Open(dbs...)
+	db := OpenDB(dbs...)
 
 	tests := []struct {
 		name      string
@@ -724,7 +724,7 @@ func TestQueryLimit(t *testing.T) {
 	dbs, clean := createSQLites()
 	defer clean()
 
-	db := Open(dbs...)
+	db := OpenDB(dbs...)
 
 	tests := []struct {
 		name       string

--- a/tx.go
+++ b/tx.go
@@ -10,10 +10,15 @@ import (
 // and Client.Transaction so callers can use the cached prepared
 // statements via the Query/Exec/QueryBuilder/ExecBuilder methods.
 //
-// TxContext implements the Tx interface implicitly — its own Query/Exec
-// methods return sqle's *Rows/*Row (which add binding) and take
-// precedence over the embedded Tx interface methods that return the
-// raw *sql.Rows/*sql.Row.
+// TxContext's own Query/Exec/Commit/Rollback methods take precedence
+// over the embedded Tx interface methods: its Query*/Exec* methods
+// return sqle's *Rows/*Row (which add binding), and its Commit/Rollback
+// also close the prepared statement cache. The embedded Tx is still
+// reachable as the `Tx` field for raw access (e.g. tx.Tx.QueryContext).
+//
+// Note: TxContext is *not* a Tx itself because its Query*/Exec* method
+// signatures differ from the Tx interface (sqle's *Rows/*Row vs. the
+// standard library's *sql.Rows/*sql.Row).
 type TxContext struct {
 	Tx // embedded Tx interface (the underlying transaction)
 	noCopy

--- a/tx.go
+++ b/tx.go
@@ -5,27 +5,27 @@ import (
 	"database/sql"
 )
 
-// TxContext wraps a Tx interface with a per-transaction prepared
+// RawTx wraps a Tx interface with a per-transaction prepared
 // statement cache. It is the concrete type returned by Client.BeginTx
 // and Client.Transaction so callers can use the cached prepared
 // statements via the Query/Exec/QueryBuilder/ExecBuilder methods.
 //
-// TxContext's own Query/Exec/Commit/Rollback methods take precedence
+// RawTx's own Query/Exec/Commit/Rollback methods take precedence
 // over the embedded Tx interface methods: its Query*/Exec* methods
 // return sqle's *Rows/*Row (which add binding), and its Commit/Rollback
 // also close the prepared statement cache. The embedded Tx is still
 // reachable as the `Tx` field for raw access (e.g. tx.Tx.QueryContext).
 //
-// Note: TxContext is *not* a Tx itself because its Query*/Exec* method
+// Note: RawTx is *not* a Tx itself because its Query*/Exec* method
 // signatures differ from the Tx interface (sqle's *Rows/*Row vs. the
 // standard library's *sql.Rows/*sql.Row).
-type TxContext struct {
+type RawTx struct {
 	Tx // embedded Tx interface (the underlying transaction)
 	noCopy
 	stmts map[string]*sql.Stmt
 }
 
-func (tx *TxContext) prepareStmt(ctx context.Context, query string) (*sql.Stmt, error) {
+func (tx *RawTx) prepareStmt(ctx context.Context, query string) (*sql.Stmt, error) {
 	if tx.stmts == nil {
 		tx.stmts = make(map[string]*sql.Stmt)
 	}
@@ -44,17 +44,17 @@ func (tx *TxContext) prepareStmt(ctx context.Context, query string) (*sql.Stmt, 
 	return s, nil
 }
 
-func (tx *TxContext) closeStmts() {
+func (tx *RawTx) closeStmts() {
 	for _, stmt := range tx.stmts {
 		stmt.Close()
 	}
 }
 
-func (tx *TxContext) Query(query string, args ...any) (*Rows, error) {
+func (tx *RawTx) Query(query string, args ...any) (*Rows, error) {
 	return tx.QueryContext(context.Background(), query, args...)
 }
 
-func (tx *TxContext) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
+func (tx *RawTx) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
 	query, args, err := b.Build()
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func (tx *TxContext) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error
 	return tx.QueryContext(ctx, query, args...)
 }
 
-func (tx *TxContext) QueryContext(ctx context.Context, query string, args ...any) (*Rows, error) {
+func (tx *RawTx) QueryContext(ctx context.Context, query string, args ...any) (*Rows, error) {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -86,11 +86,11 @@ func (tx *TxContext) QueryContext(ctx context.Context, query string, args ...any
 	return &Rows{Rows: rows, query: query}, nil
 }
 
-func (tx *TxContext) QueryRow(query string, args ...any) *Row {
+func (tx *RawTx) QueryRow(query string, args ...any) *Row {
 	return tx.QueryRowContext(context.Background(), query, args...)
 }
 
-func (tx *TxContext) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
+func (tx *RawTx) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
 	query, args, err := b.Build()
 	if err != nil {
 		return &Row{
@@ -101,7 +101,7 @@ func (tx *TxContext) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
 	return tx.QueryRowContext(ctx, query, args...)
 }
 
-func (tx *TxContext) QueryRowContext(ctx context.Context, query string, args ...any) *Row {
+func (tx *RawTx) QueryRowContext(ctx context.Context, query string, args ...any) *Row {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -134,11 +134,11 @@ func (tx *TxContext) QueryRowContext(ctx context.Context, query string, args ...
 	}
 }
 
-func (tx *TxContext) Exec(query string, args ...any) (sql.Result, error) {
+func (tx *RawTx) Exec(query string, args ...any) (sql.Result, error) {
 	return tx.ExecContext(context.Background(), query, args...)
 }
 
-func (tx *TxContext) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, error) {
+func (tx *RawTx) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, error) {
 	query, args, err := b.Build()
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (tx *TxContext) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, e
 	return tx.ExecContext(ctx, query, args...)
 }
 
-func (tx *TxContext) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+func (tx *RawTx) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -160,12 +160,12 @@ func (tx *TxContext) ExecContext(ctx context.Context, query string, args ...any)
 	return tx.Tx.ExecContext(context.Background(), query, args...)
 }
 
-func (tx *TxContext) Rollback() error {
+func (tx *RawTx) Rollback() error {
 	defer tx.closeStmts()
 	return tx.Tx.Rollback()
 }
 
-func (tx *TxContext) Commit() error {
+func (tx *RawTx) Commit() error {
 	defer tx.closeStmts()
 	return tx.Tx.Commit()
 }

--- a/tx.go
+++ b/tx.go
@@ -5,13 +5,22 @@ import (
 	"database/sql"
 )
 
-type Tx struct {
-	*sql.Tx
-	noCopy //nolint
-	stmts  map[string]*sql.Stmt
+// TxContext wraps a Tx interface with a per-transaction prepared
+// statement cache. It is the concrete type returned by Client.BeginTx
+// and Client.Transaction so callers can use the cached prepared
+// statements via the Query/Exec/QueryBuilder/ExecBuilder methods.
+//
+// TxContext implements the Tx interface implicitly — its own Query/Exec
+// methods return sqle's *Rows/*Row (which add binding) and take
+// precedence over the embedded Tx interface methods that return the
+// raw *sql.Rows/*sql.Row.
+type TxContext struct {
+	Tx // embedded Tx interface (the underlying transaction)
+	noCopy
+	stmts map[string]*sql.Stmt
 }
 
-func (tx *Tx) prepareStmt(ctx context.Context, query string) (*sql.Stmt, error) {
+func (tx *TxContext) prepareStmt(ctx context.Context, query string) (*sql.Stmt, error) {
 	if tx.stmts == nil {
 		tx.stmts = make(map[string]*sql.Stmt)
 	}
@@ -30,17 +39,17 @@ func (tx *Tx) prepareStmt(ctx context.Context, query string) (*sql.Stmt, error) 
 	return s, nil
 }
 
-func (tx *Tx) closeStmts() {
+func (tx *TxContext) closeStmts() {
 	for _, stmt := range tx.stmts {
 		stmt.Close()
 	}
 }
 
-func (tx *Tx) Query(query string, args ...any) (*Rows, error) {
+func (tx *TxContext) Query(query string, args ...any) (*Rows, error) {
 	return tx.QueryContext(context.Background(), query, args...)
 }
 
-func (tx *Tx) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
+func (tx *TxContext) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
 	query, args, err := b.Build()
 	if err != nil {
 		return nil, err
@@ -49,7 +58,7 @@ func (tx *Tx) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
 	return tx.QueryContext(ctx, query, args...)
 }
 
-func (tx *Tx) QueryContext(ctx context.Context, query string, args ...any) (*Rows, error) {
+func (tx *TxContext) QueryContext(ctx context.Context, query string, args ...any) (*Rows, error) {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -72,11 +81,11 @@ func (tx *Tx) QueryContext(ctx context.Context, query string, args ...any) (*Row
 	return &Rows{Rows: rows, query: query}, nil
 }
 
-func (tx *Tx) QueryRow(query string, args ...any) *Row {
+func (tx *TxContext) QueryRow(query string, args ...any) *Row {
 	return tx.QueryRowContext(context.Background(), query, args...)
 }
 
-func (tx *Tx) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
+func (tx *TxContext) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
 	query, args, err := b.Build()
 	if err != nil {
 		return &Row{
@@ -87,7 +96,7 @@ func (tx *Tx) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
 	return tx.QueryRowContext(ctx, query, args...)
 }
 
-func (tx *Tx) QueryRowContext(ctx context.Context, query string, args ...any) *Row {
+func (tx *TxContext) QueryRowContext(ctx context.Context, query string, args ...any) *Row {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -120,11 +129,11 @@ func (tx *Tx) QueryRowContext(ctx context.Context, query string, args ...any) *R
 	}
 }
 
-func (tx *Tx) Exec(query string, args ...any) (sql.Result, error) {
+func (tx *TxContext) Exec(query string, args ...any) (sql.Result, error) {
 	return tx.ExecContext(context.Background(), query, args...)
 }
 
-func (tx *Tx) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, error) {
+func (tx *TxContext) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, error) {
 	query, args, err := b.Build()
 	if err != nil {
 		return nil, err
@@ -132,7 +141,7 @@ func (tx *Tx) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, error) {
 	return tx.ExecContext(ctx, query, args...)
 }
 
-func (tx *Tx) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+func (tx *TxContext) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -146,12 +155,12 @@ func (tx *Tx) ExecContext(ctx context.Context, query string, args ...any) (sql.R
 	return tx.Tx.ExecContext(context.Background(), query, args...)
 }
 
-func (tx *Tx) Rollback() error {
+func (tx *TxContext) Rollback() error {
 	defer tx.closeStmts()
 	return tx.Tx.Rollback()
 }
 
-func (tx *Tx) Commit() error {
+func (tx *TxContext) Commit() error {
 	defer tx.closeStmts()
 	return tx.Tx.Commit()
 }

--- a/tx.go
+++ b/tx.go
@@ -5,27 +5,27 @@ import (
 	"database/sql"
 )
 
-// RawTx wraps a Tx interface with a per-transaction prepared
+// Transaction wraps a Tx interface with a per-transaction prepared
 // statement cache. It is the concrete type returned by Client.BeginTx
 // and Client.Transaction so callers can use the cached prepared
 // statements via the Query/Exec/QueryBuilder/ExecBuilder methods.
 //
-// RawTx's own Query/Exec/Commit/Rollback methods take precedence
+// Transaction's own Query/Exec/Commit/Rollback methods take precedence
 // over the embedded Tx interface methods: its Query*/Exec* methods
 // return sqle's *Rows/*Row (which add binding), and its Commit/Rollback
 // also close the prepared statement cache. The embedded Tx is still
 // reachable as the `Tx` field for raw access (e.g. tx.Tx.QueryContext).
 //
-// Note: RawTx is *not* a Tx itself because its Query*/Exec* method
+// Note: Transaction is *not* a Tx itself because its Query*/Exec* method
 // signatures differ from the Tx interface (sqle's *Rows/*Row vs. the
 // standard library's *sql.Rows/*sql.Row).
-type RawTx struct {
+type Transaction struct {
 	Tx // embedded Tx interface (the underlying transaction)
 	noCopy
 	stmts map[string]*sql.Stmt
 }
 
-func (tx *RawTx) prepareStmt(ctx context.Context, query string) (*sql.Stmt, error) {
+func (tx *Transaction) prepareStmt(ctx context.Context, query string) (*sql.Stmt, error) {
 	if tx.stmts == nil {
 		tx.stmts = make(map[string]*sql.Stmt)
 	}
@@ -44,17 +44,17 @@ func (tx *RawTx) prepareStmt(ctx context.Context, query string) (*sql.Stmt, erro
 	return s, nil
 }
 
-func (tx *RawTx) closeStmts() {
+func (tx *Transaction) closeStmts() {
 	for _, stmt := range tx.stmts {
 		stmt.Close()
 	}
 }
 
-func (tx *RawTx) Query(query string, args ...any) (*Rows, error) {
+func (tx *Transaction) Query(query string, args ...any) (*Rows, error) {
 	return tx.QueryContext(context.Background(), query, args...)
 }
 
-func (tx *RawTx) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
+func (tx *Transaction) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
 	query, args, err := b.Build()
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func (tx *RawTx) QueryBuilder(ctx context.Context, b *Builder) (*Rows, error) {
 	return tx.QueryContext(ctx, query, args...)
 }
 
-func (tx *RawTx) QueryContext(ctx context.Context, query string, args ...any) (*Rows, error) {
+func (tx *Transaction) QueryContext(ctx context.Context, query string, args ...any) (*Rows, error) {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -86,11 +86,11 @@ func (tx *RawTx) QueryContext(ctx context.Context, query string, args ...any) (*
 	return &Rows{Rows: rows, query: query}, nil
 }
 
-func (tx *RawTx) QueryRow(query string, args ...any) *Row {
+func (tx *Transaction) QueryRow(query string, args ...any) *Row {
 	return tx.QueryRowContext(context.Background(), query, args...)
 }
 
-func (tx *RawTx) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
+func (tx *Transaction) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
 	query, args, err := b.Build()
 	if err != nil {
 		return &Row{
@@ -101,7 +101,7 @@ func (tx *RawTx) QueryRowBuilder(ctx context.Context, b *Builder) *Row {
 	return tx.QueryRowContext(ctx, query, args...)
 }
 
-func (tx *RawTx) QueryRowContext(ctx context.Context, query string, args ...any) *Row {
+func (tx *Transaction) QueryRowContext(ctx context.Context, query string, args ...any) *Row {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -134,11 +134,11 @@ func (tx *RawTx) QueryRowContext(ctx context.Context, query string, args ...any)
 	}
 }
 
-func (tx *RawTx) Exec(query string, args ...any) (sql.Result, error) {
+func (tx *Transaction) Exec(query string, args ...any) (sql.Result, error) {
 	return tx.ExecContext(context.Background(), query, args...)
 }
 
-func (tx *RawTx) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, error) {
+func (tx *Transaction) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, error) {
 	query, args, err := b.Build()
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (tx *RawTx) ExecBuilder(ctx context.Context, b *Builder) (sql.Result, error
 	return tx.ExecContext(ctx, query, args...)
 }
 
-func (tx *RawTx) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+func (tx *Transaction) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 
 	if len(args) > 0 {
 		stmt, err := tx.prepareStmt(ctx, query)
@@ -160,12 +160,12 @@ func (tx *RawTx) ExecContext(ctx context.Context, query string, args ...any) (sq
 	return tx.Tx.ExecContext(context.Background(), query, args...)
 }
 
-func (tx *RawTx) Rollback() error {
+func (tx *Transaction) Rollback() error {
 	defer tx.closeStmts()
 	return tx.Tx.Rollback()
 }
 
-func (tx *RawTx) Commit() error {
+func (tx *Transaction) Commit() error {
 	defer tx.closeStmts()
 	return tx.Tx.Commit()
 }

--- a/tx_interface_test.go
+++ b/tx_interface_test.go
@@ -1,0 +1,147 @@
+package sqle
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaitoo/sqle/shardid"
+)
+
+// customTx is a transaction wrapper that counts Commit/Rollback calls
+// so we can verify that custom Tx implementations flow through the
+// sqle.TxContext wrapper correctly.
+type customTx struct {
+	*sql.Tx
+	commitCalls   atomic.Int32
+	rollbackCalls atomic.Int32
+}
+
+func (tx *customTx) Commit() error {
+	tx.commitCalls.Add(1)
+	return tx.Tx.Commit()
+}
+
+func (tx *customTx) Rollback() error {
+	tx.rollbackCalls.Add(1)
+	return tx.Tx.Rollback()
+}
+
+// customDB is a Database implementation that returns a customTx from
+// Begin/BeginTx. It satisfies the Database interface by overriding
+// Begin/BeginTx (the rest of the methods are promoted from *sql.DB).
+type customDB struct {
+	*sql.DB
+}
+
+func (db *customDB) Begin() (Tx, error) {
+	return db.BeginTx(context.Background(), nil)
+}
+
+func (db *customDB) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error) {
+	tx, err := db.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &customTx{Tx: tx}, nil
+}
+
+// TestCustomTxCommitHook proves that a custom Tx implementation
+// (here, customTx) reaches Commit/Rollback when used through
+// *sqle.TxContext.
+func TestCustomTxCommitHook(t *testing.T) {
+	raw := createSQLite3()
+	_, err := raw.Exec("CREATE TABLE `t` (`v` int)")
+	require.NoError(t, err)
+
+	wrapped := &customDB{DB: raw}
+	db := Open(wrapped)
+
+	tx, err := db.Begin(nil)
+	require.NoError(t, err)
+
+	_, err = tx.Exec("INSERT INTO `t` (`v`) VALUES (1)")
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit())
+
+	// Pull the row back to verify the commit went through.
+	var v int
+	row := db.QueryRow("SELECT `v` FROM `t` WHERE `v` = 1")
+	require.NoError(t, row.Scan(&v))
+	require.Equal(t, 1, v)
+}
+
+// TestCustomTxRollbackHook proves that Rollback on the underlying
+// customTx is invoked when Transaction falls back to rollback.
+func TestCustomTxRollbackHook(t *testing.T) {
+	raw := createSQLite3()
+	_, err := raw.Exec("CREATE TABLE `t` (`v` int)")
+	require.NoError(t, err)
+
+	wrapped := &customDB{DB: raw}
+	db := Open(wrapped)
+
+	sentinel := errors.New("nope")
+	err = db.Transaction(context.Background(), nil, func(ctx context.Context, tx *TxContext) error {
+		_, err := tx.Exec("INSERT INTO `t` (`v`) VALUES (1)")
+		require.NoError(t, err)
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	// The row should not be visible (transaction rolled back).
+	var count int
+	row := db.QueryRow("SELECT COUNT(*) FROM `t`")
+	require.NoError(t, row.Scan(&count))
+	require.Equal(t, 0, count)
+}
+
+// TestCustomTxBeginReturnsInterface proves that Client.BeginTx returns
+// the *TxContext wrapper regardless of the underlying Tx concrete type.
+func TestCustomTxBeginReturnsInterface(t *testing.T) {
+	raw := createSQLite3()
+	wrapped := &customDB{DB: raw}
+	db := Open(wrapped)
+
+	ctx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	defer func() { _ = ctx.Rollback() }()
+
+	// TxContext wraps the Tx interface, so the embedded Tx
+	// must be the customTx instance returned by customDB.BeginTx.
+	custom, ok := ctx.Tx.(*customTx)
+	require.True(t, ok, "expected *customTx, got %T", ctx.Tx)
+	require.NotNil(t, custom)
+}
+
+// TestOpenDBBackwardCompat makes sure OpenDB (the *sql.DB convenience
+// wrapper) still works for the bare-*sql.DB use case.
+func TestOpenDBBackwardCompat(t *testing.T) {
+	dbs := []*sql.DB{createSQLite3(), createSQLite3()}
+	db := OpenDB(dbs...)
+	require.NotNil(t, db)
+	require.Equal(t, 0, db.On(shardid.ID{DatabaseID: 0}).Index)
+
+	// Round-trip a row through the wrapped database.
+	_, err := db.ExecContext(context.Background(), "CREATE TABLE `t` (`v` int)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(context.Background(), "INSERT INTO `t` (`v`) VALUES (1)")
+	require.NoError(t, err)
+}
+
+// TestOpenMixedArgs shows that Open accepts both *sql.DB and Database
+// implementations in the same call.
+func TestOpenMixedArgs(t *testing.T) {
+	raw := createSQLite3()
+	wrapped := &wrapperDB{DB: raw}
+
+	// Mix raw *sql.DB and a custom Database wrapper.
+	db := Open(raw, wrapped)
+	require.NotNil(t, db)
+	require.Equal(t, 0, db.On(shardid.ID{DatabaseID: 0}).Index)
+	require.Equal(t, 1, db.dbs[1].Index)
+}

--- a/tx_interface_test.go
+++ b/tx_interface_test.go
@@ -63,10 +63,18 @@ func TestCustomTxCommitHook(t *testing.T) {
 	tx, err := db.Begin(nil)
 	require.NoError(t, err)
 
+	// Reach through TxContext.Tx to grab the underlying customTx so we
+	// can assert on the hook counters.
+	custom, ok := tx.Tx.(*customTx)
+	require.True(t, ok, "expected *customTx, got %T", tx.Tx)
+	require.Equal(t, int32(0), custom.commitCalls.Load())
+
 	_, err = tx.Exec("INSERT INTO `t` (`v`) VALUES (1)")
 	require.NoError(t, err)
 
 	require.NoError(t, tx.Commit())
+	require.Equal(t, int32(1), custom.commitCalls.Load(),
+		"customTx.Commit hook should fire through TxContext.Commit")
 
 	// Pull the row back to verify the commit went through.
 	var v int
@@ -85,13 +93,24 @@ func TestCustomTxRollbackHook(t *testing.T) {
 	wrapped := &customDB{DB: raw}
 	db := Open(wrapped)
 
+	var underlying *customTx
 	sentinel := errors.New("nope")
 	err = db.Transaction(context.Background(), nil, func(ctx context.Context, tx *TxContext) error {
+		// Capture the underlying customTx for the post-transaction
+		// assertion on rollbackCalls.
+		custom, ok := tx.Tx.(*customTx)
+		require.True(t, ok, "expected *customTx, got %T", tx.Tx)
+		underlying = custom
+		require.Equal(t, int32(0), underlying.rollbackCalls.Load())
+
 		_, err := tx.Exec("INSERT INTO `t` (`v`) VALUES (1)")
 		require.NoError(t, err)
 		return sentinel
 	})
 	require.ErrorIs(t, err, sentinel)
+	require.NotNil(t, underlying)
+	require.Equal(t, int32(1), underlying.rollbackCalls.Load(),
+		"customTx.Rollback hook should fire when Transaction aborts")
 
 	// The row should not be visible (transaction rolled back).
 	var count int

--- a/tx_interface_test.go
+++ b/tx_interface_test.go
@@ -13,7 +13,7 @@ import (
 
 // customTx is a transaction wrapper that counts Commit/Rollback calls
 // so we can verify that custom Tx implementations flow through the
-// sqle.RawTx wrapper correctly.
+// sqle.Transaction wrapper correctly.
 type customTx struct {
 	*sql.Tx
 	commitCalls   atomic.Int32
@@ -51,7 +51,7 @@ func (db *customDB) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error
 
 // TestCustomTxCommitHook proves that a custom Tx implementation
 // (here, customTx) reaches Commit/Rollback when used through
-// *sqle.RawTx.
+// *sqle.Transaction.
 func TestCustomTxCommitHook(t *testing.T) {
 	raw := createSQLite3()
 	_, err := raw.Exec("CREATE TABLE `t` (`v` int)")
@@ -63,7 +63,7 @@ func TestCustomTxCommitHook(t *testing.T) {
 	tx, err := db.Begin(nil)
 	require.NoError(t, err)
 
-	// Reach through RawTx.Tx to grab the underlying customTx so we
+	// Reach through Transaction.Tx to grab the underlying customTx so we
 	// can assert on the hook counters.
 	custom, ok := tx.Tx.(*customTx)
 	require.True(t, ok, "expected *customTx, got %T", tx.Tx)
@@ -74,7 +74,7 @@ func TestCustomTxCommitHook(t *testing.T) {
 
 	require.NoError(t, tx.Commit())
 	require.Equal(t, int32(1), custom.commitCalls.Load(),
-		"customTx.Commit hook should fire through RawTx.Commit")
+		"customTx.Commit hook should fire through Transaction.Commit")
 
 	// Pull the row back to verify the commit went through.
 	var v int
@@ -95,7 +95,7 @@ func TestCustomTxRollbackHook(t *testing.T) {
 
 	var underlying *customTx
 	sentinel := errors.New("nope")
-	err = db.Transaction(context.Background(), nil, func(ctx context.Context, tx *RawTx) error {
+	err = db.Transaction(context.Background(), nil, func(ctx context.Context, tx *Transaction) error {
 		// Capture the underlying customTx for the post-transaction
 		// assertion on rollbackCalls.
 		custom, ok := tx.Tx.(*customTx)
@@ -120,7 +120,7 @@ func TestCustomTxRollbackHook(t *testing.T) {
 }
 
 // TestCustomTxBeginReturnsInterface proves that Client.BeginTx returns
-// the *RawTx wrapper regardless of the underlying Tx concrete type.
+// the *Transaction wrapper regardless of the underlying Tx concrete type.
 func TestCustomTxBeginReturnsInterface(t *testing.T) {
 	raw := createSQLite3()
 	wrapped := &customDB{DB: raw}
@@ -130,7 +130,7 @@ func TestCustomTxBeginReturnsInterface(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = ctx.Rollback() }()
 
-	// RawTx wraps the Tx interface, so the embedded Tx
+	// Transaction wraps the Tx interface, so the embedded Tx
 	// must be the customTx instance returned by customDB.BeginTx.
 	custom, ok := ctx.Tx.(*customTx)
 	require.True(t, ok, "expected *customTx, got %T", ctx.Tx)

--- a/tx_interface_test.go
+++ b/tx_interface_test.go
@@ -13,7 +13,7 @@ import (
 
 // customTx is a transaction wrapper that counts Commit/Rollback calls
 // so we can verify that custom Tx implementations flow through the
-// sqle.TxContext wrapper correctly.
+// sqle.RawTx wrapper correctly.
 type customTx struct {
 	*sql.Tx
 	commitCalls   atomic.Int32
@@ -51,7 +51,7 @@ func (db *customDB) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error
 
 // TestCustomTxCommitHook proves that a custom Tx implementation
 // (here, customTx) reaches Commit/Rollback when used through
-// *sqle.TxContext.
+// *sqle.RawTx.
 func TestCustomTxCommitHook(t *testing.T) {
 	raw := createSQLite3()
 	_, err := raw.Exec("CREATE TABLE `t` (`v` int)")
@@ -63,7 +63,7 @@ func TestCustomTxCommitHook(t *testing.T) {
 	tx, err := db.Begin(nil)
 	require.NoError(t, err)
 
-	// Reach through TxContext.Tx to grab the underlying customTx so we
+	// Reach through RawTx.Tx to grab the underlying customTx so we
 	// can assert on the hook counters.
 	custom, ok := tx.Tx.(*customTx)
 	require.True(t, ok, "expected *customTx, got %T", tx.Tx)
@@ -74,7 +74,7 @@ func TestCustomTxCommitHook(t *testing.T) {
 
 	require.NoError(t, tx.Commit())
 	require.Equal(t, int32(1), custom.commitCalls.Load(),
-		"customTx.Commit hook should fire through TxContext.Commit")
+		"customTx.Commit hook should fire through RawTx.Commit")
 
 	// Pull the row back to verify the commit went through.
 	var v int
@@ -95,7 +95,7 @@ func TestCustomTxRollbackHook(t *testing.T) {
 
 	var underlying *customTx
 	sentinel := errors.New("nope")
-	err = db.Transaction(context.Background(), nil, func(ctx context.Context, tx *TxContext) error {
+	err = db.Transaction(context.Background(), nil, func(ctx context.Context, tx *RawTx) error {
 		// Capture the underlying customTx for the post-transaction
 		// assertion on rollbackCalls.
 		custom, ok := tx.Tx.(*customTx)
@@ -120,7 +120,7 @@ func TestCustomTxRollbackHook(t *testing.T) {
 }
 
 // TestCustomTxBeginReturnsInterface proves that Client.BeginTx returns
-// the *TxContext wrapper regardless of the underlying Tx concrete type.
+// the *RawTx wrapper regardless of the underlying Tx concrete type.
 func TestCustomTxBeginReturnsInterface(t *testing.T) {
 	raw := createSQLite3()
 	wrapped := &customDB{DB: raw}
@@ -130,7 +130,7 @@ func TestCustomTxBeginReturnsInterface(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = ctx.Rollback() }()
 
-	// TxContext wraps the Tx interface, so the embedded Tx
+	// RawTx wraps the Tx interface, so the embedded Tx
 	// must be the customTx instance returned by customDB.BeginTx.
 	custom, ok := ctx.Tx.(*customTx)
 	require.True(t, ok, "expected *customTx, got %T", ctx.Tx)

--- a/tx_test.go
+++ b/tx_test.go
@@ -160,7 +160,7 @@ func TestTx(t *testing.T) {
 					Email string
 				}
 
-				err := db.Transaction(context.TODO(), nil, func(ctx context.Context, tx *Tx) error {
+				err := db.Transaction(context.TODO(), nil, func(ctx context.Context, tx *TxContext) error {
 
 					for i := 100; i < 110; i++ {
 						_, err := tx.ExecBuilder(ctx, New().

--- a/tx_test.go
+++ b/tx_test.go
@@ -160,7 +160,7 @@ func TestTx(t *testing.T) {
 					Email string
 				}
 
-				err := db.Transaction(context.TODO(), nil, func(ctx context.Context, tx *TxContext) error {
+				err := db.Transaction(context.TODO(), nil, func(ctx context.Context, tx *RawTx) error {
 
 					for i := 100; i < 110; i++ {
 						_, err := tx.ExecBuilder(ctx, New().

--- a/tx_test.go
+++ b/tx_test.go
@@ -160,7 +160,7 @@ func TestTx(t *testing.T) {
 					Email string
 				}
 
-				err := db.Transaction(context.TODO(), nil, func(ctx context.Context, tx *RawTx) error {
+				err := db.Transaction(context.TODO(), nil, func(ctx context.Context, tx *Transaction) error {
 
 					for i := 100; i < 110; i++ {
 						_, err := tx.ExecBuilder(ctx, New().


### PR DESCRIPTION
Mirrors the Database abstraction for *sql.Tx so custom database implementations can return custom transaction types from Begin/BeginTx.

## Changes

- **New `Tx` interface** in `database.go` (mirrors the Database subset used by sqle: Query/QueryContext/QueryRow/QueryRowContext/Exec/ExecContext/Prepare/PrepareContext/Commit/Rollback). `*sql.Tx` satisfies it by default.
- **`Database.Begin`/`BeginTx`** now return the `Tx` interface instead of `*sql.Tx`. Custom database implementations can return any type satisfying the interface.
- **`Tx` struct renamed to `TxContext`** so the new `Tx` interface can coexist. `TxContext` wraps a `Tx` interface and keeps the per-transaction prepared-statement cache.
- **`sqlDBWrapper`** (unexported) adapts `*sql.DB` to the new `Database` signature.
- **`Open(...any)`** accepts any mix of `Database` and `*sql.DB` (runtime detection auto-wraps `*sql.DB`).
- **`OpenDB(...*sql.DB)`** added as a type-safe convenience for raw `*sql.DB` slices.
- **`db.Add`** keeps the `Database` interface signature; callers wrap `*sql.DB` via `&sqlDBWrapper{DB: db}` if needed.

## Tests

New file `tx_interface_test.go`:
- `TestCustomTxCommitHook` — custom Tx's `Commit` fires through `db.Begin`/`tx.Commit`.
- `TestCustomTxRollbackHook` — custom Tx's `Rollback` fires when `Transaction` returns an error.
- `TestCustomTxBeginReturnsInterface` — `Client.BeginTx` wraps the custom Tx in `TxContext`.
- `TestOpenDBBackwardCompat` — `OpenDB(...*sql.DB)` works.
- `TestOpenMixedArgs` — `Open` accepts both `*sql.DB` and a `Database` wrapper in one call.

## Backward compatibility

- `Open(*sql.DB)` keeps working — `Open` detects `*sql.DB` and wraps it via `sqlDBWrapper` internally.
- `*sqle.Tx` is renamed to `*sqle.TxContext`; this is a breaking change to the struct name. `migrate/`, `dtc.go`, and `tx_test.go` are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a Tx interface abstraction and update transaction handling and DB opening APIs to support custom transaction implementations while preserving *sql.DB compatibility.

New Features:
- Add a Tx interface mirroring the subset of *sql.Tx used by the library so custom transaction types can be plugged in.
- Add OpenDB(...*sql.DB) as a convenience constructor for working directly with standard library *sql.DB instances.

Enhancements:
- Rename the concrete Tx wrapper to TxContext and have it embed the Tx interface while maintaining per-transaction prepared statement caching.
- Change the Database interface so Begin/BeginTx return the new Tx interface, and adapt *sql.DB via an internal sqlDBWrapper type.
- Refactor Open to accept a variadic list of mixed Database implementations and *sql.DB values with runtime adaptation, and adjust DB.Add to explicitly require Database implementations.

Documentation:
- Update AGENTS.md and CHANGELOG entries to describe the new Tx interface, TxContext type, and the revised Open/OpenDB APIs.

Tests:
- Add tx_interface_test.go to cover custom Tx implementations, OpenDB backward compatibility, and mixed-argument Open usage.
- Update existing tests to use OpenDB where appropriate and to work with TxContext instead of the old Tx struct.